### PR TITLE
Fix: IT Problem page didn't show all related items

### DIFF
--- a/module/plugins/problems/problems.py
+++ b/module/plugins/problems/problems.py
@@ -118,11 +118,12 @@ def get_view(page):
     my_items = only_related_to(items, user)
 
     # Check for related host contacts
-    for i in items:
-      if isinstance(i,Service):
-        if user in i.host.contacts:
-          my_items.append(i)
-          continue
+    if not user.is_admin:
+      for i in items:
+        if isinstance(i,Service):
+          if user in i.host.contacts:
+            my_items.append(i)
+            continue
 
     items = my_items
 


### PR DESCRIPTION
Hi,

In the only_related_to function we only check if
- tested element have related contact
- if the source problem have related contact
- if related impacts have related contact
  but we didn't test if host of current critical service have related
  contact.

Here I've add the ability to check if host of the service have related
contact and should be displayed.

I'm not sure it's the best way to display some services into IT Problem page for my Customer but this work :).

Feel free to discuss the PR.

Regards
