### PR TITLE
More detailed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,28 @@ Shinken main Web interface
 
 ###Installation
 
-* *$ shinken install webui*
+* Install the webui module from shinken.io
+```
+$ shinken install webui
+```
 * Add it into the modules of the broker configuration :
 ```
-shinken@debian# cat /etc/shinken/brokers/broker-master.cfg
+$ cat /etc/shinken/brokers/broker-master.cfg
 [...]
 modules     webui
 [...]
 ```
-* Install an authentication module for instance 
+* Install an authentication module. For instance 
 ```
-shinken install auth-cfg-password
+$ shinken install auth-cfg-password
 ```
 
 * Declare it on the WebUI configuration :
 ```
-shinken@debian# grep modules /etc/shinken/modules/webui.cfg
+$ cat /etc/shinken/modules/webui.cfg
+[...]
 modules             auth-cfg-password
+[...]
 ```
 * Restart shinken and connect to the WebUI that will be available on the 7767 port.
 ```


### PR DESCRIPTION
This was my first time with Shinken and I got tripped by the outdated docs on the .org site. Had trouble finding the readthedocs doc (probably because of google indexing) but still the doc there wasn't detailed for a first time module installation (I guess I wouldn't be the only first time installer looking into webui as a first module), had to search in the forum, undesrstand there was some kind of video or tutorial, and finally found more detailed instructions on Naparuba's course's github. How about also updating the shinken.io webui module installation steps!
