### PR TITLE
General worldmap plugin improvements

### DIFF
--- a/module/plugins/worldmap/plugin.cfg
+++ b/module/plugins/worldmap/plugin.cfg
@@ -1,4 +1,6 @@
 [plugin]
+# Draw only hosts with latitude and longitude attributes
+only_geo_hosts=False
 # Default position/zoom
 # France / Romans is default camera position
 default_Lat=45.054485

--- a/module/plugins/worldmap/worldmap.py
+++ b/module/plugins/worldmap/worldmap.py
@@ -39,6 +39,7 @@ try:
     scp = config_parser('#', '=')
     params = scp.parse_config(configuration_file)
 
+    params['only_geo_hosts'] = bool(params['only_geo_hosts'])
     params['default_Lat'] = float(params['default_Lat'])
     params['default_Lng'] = float(params['default_Lng'])
     params['default_zoom'] = int(params['default_zoom'])
@@ -58,6 +59,41 @@ def checkauth():
     else:
         return user
 
+def _valid_coords(hostname, lat, lng):
+
+    COORD_MAX = 180
+    COORD_MIN = -180
+
+    if not lat and not lng:
+        return False
+
+    logger.debug("[worldmap] {}: {},{}".format(hostname, lat, lng))
+
+    try:
+        # Maybe the customs are set, but with invalid float?
+        lat = float(lat)
+        lng = float(lng)
+    except ValueError:
+        logger.warning("[worldmap] Host {} has invalid coordinates".format(hostname))
+        return False
+
+    if lat >= COORD_MAX or lat <= COORD_MIN:
+        logger.warning("[worldmap] Host {} has a latitude out of range".format(hostname))
+        return False
+
+    if lng >= COORD_MAX or lng <= COORD_MIN:
+        logger.warning("[worldmap] Host {} has a longitude out of range".format(hostname))
+        return False
+
+    return True
+
+def _get_coords(host):
+    lat = host.customs.get('_LOC_LAT', host.customs.get('_LAT'))
+    lng = host.customs.get('_LOC_LNG', host.customs.get('_LONG'))
+    if not params['only_geo_hosts']:
+        lat = params['default_Lat'] if not lat else lat
+        lng = params['default_Lng'] if not lng else lng
+    return (lat, lng)
 
 # Our page. If the user call /worldmap
 def get_page():
@@ -67,24 +103,11 @@ def get_page():
     # and we just give them to the template to print them.
     valid_hosts = []
     for h in app.datamgr.get_hosts():
-        _lat = h.customs.get('_LOC_LAT', params['default_Lat'])
-        _lng = h.customs.get('_LOC_LNG', params['default_Lng'])
-
-        try:
-            print "Host", h.get_name(), _lat, _lng
-        except:
-            pass
-        if _lat and _lng:
-            try:
-                # Maybe the customs are set, but with invalid float?
-                _lat = float(_lat)
-                _lng = float(_lng)
-            except ValueError:
-                print "Host invalid coordinates !"
-                continue
-            # Look for good range, lat/long must be between -180/180
-            if -180 <= _lat <= 180 and -180 <= _lng <= 180:
-                valid_hosts.append(h)
+        (_lat, _lng) = _get_coords(h)
+        if _valid_coords(h.get_name(), _lat, _lng):
+            h.customs['_LOC_LAT'] = _lat
+            h.customs['_LOC_LNG'] = _lng
+            valid_hosts.append(h)
 
     # So now we can just send the valid hosts to the template
     return {'app': app, 'user': user, 'params': params, 'hosts' : valid_hosts}
@@ -102,24 +125,11 @@ def worldmap_widget():
     # and we just give them to the template to print them.
     valid_hosts = []
     for h in app.datamgr.get_hosts():
-        _lat = h.customs.get('_LOC_LAT', params['default_Lat'])
-        _lng = h.customs.get('_LOC_LNG', params['default_Lng'])
-
-        try:
-            print "Host", h.get_name(), _lat, _lng
-        except:
-            pass
-        if _lat and _lng:
-            try:
-                # Maybe the customs are set, but with invalid float?
-                _lat = float(_lat)
-                _lng = float(_lng)
-            except ValueError:
-                print "Host invalid coordinates !"
-                continue
-            # Look for good range, lat/long must be between -180/180
-            if -180 <= _lat <= 180 and -180 <= _lng <= 180:
-                valid_hosts.append(h)
+        (_lat, _lng) = _get_coords(h)
+        if _valid_coords(h.get_name(), _lat, _lng):
+            h.customs['_LOC_LAT'] = _lat
+            h.customs['_LOC_LNG'] = _lng
+            valid_hosts.append(h)
                 
     return {'app': app, 'user': user, 'wid': wid,
             'collapsed': collapsed, 'options': options,


### PR DESCRIPTION
- Use _LAT and _LONG attritubes as alternative to _LOC_LAT and _LOC_LNG
  They are used, for example, by Nagvis GeoMap maps:
  https://clarin.fz-juelich.de/nagvis/docs/en_US/geomap.html
  It's a good way to keep compatibility with no user interaction
- Get and check valid coords refactoring
  Two new functions for this purpose in page and widget routing
  instead of using the same code
- New configuration variable: only_geo_hosts
  Let the user make the decision to draw only hosts with geo attributes
  Worldmap will not work in a huge infrastructure with more than 10.000 hosts
  placed in the same default point (beleive me, it doesn't work)
