### PR TITLE
Use all host info to fill the hostgroup quickinfo bar

### DIFF
--- a/module/plugins/groups/groups.py
+++ b/module/plugins/groups/groups.py
@@ -35,7 +35,7 @@ params['elts_per_page'] = 10
 
 def load_cfg():
     global params
-    
+
     import os,sys
     from shinken.log import logger
     from config_parser import config_parser
@@ -48,10 +48,10 @@ def load_cfg():
         params = scp.parse_config(configuration_file)
 
         params['elts_per_page'] = int(params['elts_per_page'])
-        
+
         logger.debug("WebUI plugin '%s', configuration loaded." % (plugin_name))
         logger.debug("Plugin configuration, elts_per_page: %d" % (params['elts_per_page']))
-        
+
         return True
     except Exception, exp:
         logger.warning("WebUI plugin '%s', configuration file (%s) not available: %s" % (plugin_name, configuration_file, str(exp)))
@@ -74,7 +74,7 @@ def show_hostgroup(name):
 
     if name == 'all':
         my_group = 'all'
-        
+
         items = []
         items.extend(app.datamgr.get_hosts())
 
@@ -83,17 +83,17 @@ def show_hostgroup(name):
 
         if not my_group:
             return "Unknown group %s" % name
-            
+
         items = my_group.get_hosts()
 
     elts_per_page = params['elts_per_page']
     # We want to limit the number of elements
     start = int(app.request.GET.get('start', '0'))
     end = int(app.request.GET.get('end', elts_per_page))
-        
+
     # Now sort hosts list ..
     items.sort(hst_srv_sort)
-        
+
     # If we overflow, came back as normal
     total = len(items)
     if start > total:
@@ -101,12 +101,12 @@ def show_hostgroup(name):
         end = elts_per_page
 
     navi = app.helper.get_navi(total, start, step=elts_per_page)
-    items = items[start:end]
-        
-    return {'app': app, 'user': user, 'params': params, 'navi': navi, 'group': my_group, 'hosts': items, 'length': total}
+    items_page = items[start:end]
+
+    return {'app': app, 'user': user, 'params': params, 'navi': navi, 'group': my_group, 'hosts': items_page, 'all_hosts': items, 'length': total}
 
 def show_hostgroups():
-    user = checkauth()    
+    user = checkauth()
 
     my_hostgroups = app.datamgr.get_hostgroups()
 
@@ -114,11 +114,11 @@ def show_hostgroups():
 
 
 def show_servicegroup(name):
-    user = checkauth()    
+    user = checkauth()
 
     if name == 'all':
         my_group = 'all'
-        
+
         services = []
         services.extend(app.datamgr.get_services())
         items = services
@@ -128,17 +128,17 @@ def show_servicegroup(name):
 
         if not my_group:
             return "Unknown group %s" % name
-            
+
         items = my_group.get_services()
 
     elts_per_page = params['elts_per_page']
     # We want to limit the number of elements
     start = int(app.request.GET.get('start', '0'))
     end = int(app.request.GET.get('end', elts_per_page))
-        
+
     # Now sort services list ..
     items.sort(hst_srv_sort)
-        
+
     # If we overflow, came back as normal
     total = len(items)
     if start > total:
@@ -147,11 +147,11 @@ def show_servicegroup(name):
 
     navi = app.helper.get_navi(total, start, step=elts_per_page)
     items = items[start:end]
-        
+
     return {'app': app, 'user': user, 'params': params, 'navi': navi, 'group': my_group, 'services': items, 'length': total}
 
 def show_servicegroups():
-    user = checkauth()    
+    user = checkauth()
 
     my_servicegroups = app.datamgr.get_servicegroups()
 

--- a/module/plugins/groups/views/hostgroup.tpl
+++ b/module/plugins/groups/views/hostgroup.tpl
@@ -23,7 +23,7 @@ Invalid group name
 %hUnreachable=0
 %hPending=0
 %hUnknown=0
-%for h in hosts:
+%for h in all_hosts:
 	%nHosts=nHosts+1
 	%if h.state == 'UP':
 		%hUp=hUp+1
@@ -38,11 +38,11 @@ Invalid group name
 	%end
 %end
 %if nHosts != 0:
-	%pctUp			= round(100.0 * hUp / nHosts, 2)
-	%pctDown		= round(100.0 * hDown / nHosts, 2)
-	%pctUnreachable	= round(100.0 * hUnreachable / nHosts, 2)
-	%pctPending		= round(100.0 * hPending / nHosts, 2)
-	%pctUnknown		= round(100.0 * hUnknown / nHosts, 2)
+	%pctUp			= round(100.0 * hUp / length, 2)
+	%pctDown		= round(100.0 * hDown / length, 2)
+	%pctUnreachable	= round(100.0 * hUnreachable / length, 2)
+	%pctPending		= round(100.0 * hPending / length, 2)
+	%pctUnknown		= round(100.0 * hUnknown / length, 2)
 %else:
 	%pctUp			= 0
 	%pctDown		= 0

--- a/module/plugins/groups/views/hostgroup.tpl
+++ b/module/plugins/groups/views/hostgroup.tpl
@@ -77,7 +77,7 @@ Invalid group name
 		</div>
 		<div class="panel-body">
 			<div class="pull-left col-lg-4">
-				<span>Currently displaying {{nHosts}} hosts out of {{length}}</span>
+				<span>Currently displaying {{nHosts}} hosts</span>
 			</div>
 			<div class="pull-right progress col-lg-7 no-bottommargin no-leftpadding no-rightpadding" style="height: 45px;">
 				<div title="{{hUp}} hosts Up" class="progress-bar progress-bar-success quickinfo" role="progressbar" 


### PR DESCRIPTION
A quickbar showing only the status of 20 hosts (page predefined) doesn't make sense. It's confusing (the first time I saw the bar, I thougth that all my hosts were up) and useless (I can see the number of down hosts in a page with 20 rows without looking at the bar).

The bar should show up the total number of hosts down/up/warning, and should not change between page changes. Here's an example with a lot of hosts:
![all_hosts](https://cloud.githubusercontent.com/assets/3034812/4953478/60423546-6681-11e4-96a6-416d903f79ea.png)
This is, IMHO, the right way to help users to know about their infrastructure status in one shot. (No need to change between N pages, 237 in this case):

![all_hosts2](https://cloud.githubusercontent.com/assets/3034812/4953426/b418ba7e-6680-11e4-9159-c5291e31b692.png)

Thanks.