### PR TITLE
Fix: fa-remove no more exist in this FA version. Use fa-tash-o.

### DIFF
--- a/module/plugins/dashboard/htdocs/js/widgets.js
+++ b/module/plugins/dashboard/htdocs/js/widgets.js
@@ -181,7 +181,7 @@ $(function(){
     var easy_widget_mgr = $.fn.EasyWidgets({
         i18n : {
             editText : '<i class="fa fa-edit font-grey"></i>',/*<img src="./edit.png" alt="Edit" width="16" height="16" />',*/
-            closeText : '<i class="fa fa-remove font-grey"></i>',
+            closeText : '<i class="fa fa-trash-o font-grey"></i>',
             collapseText : '<i class="fa fa-chevron-up font-grey"></i>',
             cancelEditText : '<i class="fa fa-edit font-grey"></i>',
             extendText : '<i class="fa fa-chevron-down font-grey"></i>',


### PR DESCRIPTION
Hi,

In the font awesome version used by the bs3 branch the icone fa-remove is not present. This PR use fa-trash-o instead.

Regards
