### PR TITLE
Fix relative import problem with config_parser

### DIFF
--- a/module/plugins/eltdetail/eltdetail.py
+++ b/module/plugins/eltdetail/eltdetail.py
@@ -48,7 +48,7 @@ def load_cfg():
     global params
     
     import os,sys
-    from config_parser import config_parser
+    from webui.config_parser import config_parser
     from shinken.log import logger
     plugin_name = os.path.splitext(os.path.basename(__file__))[0]
     try:

--- a/module/plugins/groups/groups.py
+++ b/module/plugins/groups/groups.py
@@ -38,7 +38,7 @@ def load_cfg():
     
     import os,sys
     from shinken.log import logger
-    from config_parser import config_parser
+    from webui.config_parser import config_parser
     plugin_name = os.path.splitext(os.path.basename(__file__))[0]
     try:
         currentdir = os.path.dirname(os.path.realpath(__file__))

--- a/module/plugins/system/system.py
+++ b/module/plugins/system/system.py
@@ -50,7 +50,7 @@ params['logs_hosts'] = []
 params['logs_services'] = []
 
 import os,sys
-from config_parser import config_parser
+from webui.config_parser import config_parser
 plugin_name = os.path.splitext(os.path.basename(__file__))[0]
 try:
     currentdir = os.path.dirname(os.path.realpath(__file__))

--- a/module/plugins/tags/tags.py
+++ b/module/plugins/tags/tags.py
@@ -38,7 +38,7 @@ def load_cfg():
     
     import os,sys
     from shinken.log import logger
-    from config_parser import config_parser
+    from webui.config_parser import config_parser
     plugin_name = os.path.splitext(os.path.basename(__file__))[0]
     try:
         currentdir = os.path.dirname(os.path.realpath(__file__))

--- a/module/plugins/wall/wall.py
+++ b/module/plugins/wall/wall.py
@@ -28,7 +28,7 @@ app = None
 
 import time
 
-from helper import hst_srv_sort
+from webui.helper import hst_srv_sort
 from shinken.util import safe_print
 from shinken.misc.filter  import only_related_to
 try:

--- a/module/plugins/worldmap/worldmap.py
+++ b/module/plugins/worldmap/worldmap.py
@@ -30,7 +30,7 @@ app = None
 params = {}
 
 import os,sys
-from config_parser import config_parser
+from webui.config_parser import config_parser
 plugin_name = os.path.splitext(os.path.basename(__file__))[0]
 try:
     currentdir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
With shinken 2.2 import are not global anymore and relative import must be used. 

This fix the problem on existing pages