### PR TITLE
Flapping and Downtime button should be green if not present

### DIFF
--- a/module/helper.py
+++ b/module/helper.py
@@ -63,6 +63,15 @@ class Helper(object):
         else:
             return 'No'
 
+    def up_down(self, b):
+        """
+          Return 'up' or 'down' regarding first boolean args value
+        """
+        if b:
+            return 'up'
+        else:
+            return 'down'
+
     def print_float(self, f):
         return '%.2f' % f
 

--- a/module/plugins/eltdetail/views/eltdetail.tpl
+++ b/module/plugins/eltdetail/views/eltdetail.tpl
@@ -378,11 +378,11 @@ Invalid element name
 						</tr>
 						<tr>
 							<td class="column1"><b>Flapping:</b></td>
-							<td><button class="col-lg-11 btn alert-small trim-{{helper.yes_no(elt.is_flapping)}} quickinforight" data-original-title="{{helper.print_float(elt.percent_state_change)}}% state change">{{helper.yes_no(elt.is_flapping)}}</button></td>
+							<td><button class="col-lg-11 btn alert-small alert-{{helper.up_down(not elt.is_flapping)}} quickinforight" data-original-title="{{helper.print_float(elt.percent_state_change)}}% state change">{{helper.yes_no(elt.is_flapping)}}</button></td>
 						</tr>
 						<tr>
 							<td class="column1"><b>In Scheduled Downtime?</b></td>
-							<td><button class="col-lg-11 btn alert-small trim-{{helper.yes_no(elt.in_scheduled_downtime)}}" type="button">{{helper.yes_no(elt.in_scheduled_downtime)}}</button></td>
+							<td><button class="col-lg-11 btn alert-small alert-{{helper.up_down(not elt.in_scheduled_downtime)}}" type="button">{{helper.yes_no(elt.in_scheduled_downtime)}}</button></td>
 						</tr>
 					</table>
 					<hr>


### PR DESCRIPTION
Hi,

This pull request change the "Flapping:" and "In Scheduled Downtime?" button color. 

When there is no flapping nor downtime the color is green, otherwise red.

Regards