### PR TITLE
[BS3] Improve action buttons in problems view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ nosetests.xml
 *.db
 
 # backup file
-*.py~
+*~

--- a/module/plugins/forms/views/form_ack.tpl
+++ b/module/plugins/forms/views/form_ack.tpl
@@ -1,28 +1,27 @@
 <script type="text/javascript">
-	function submit_local_form() {
-		// Launch acknowledge request and bailout this modal view
-		do_acknowledge("{{name}}", $('#reason').val(), '{{user.get_name()}}');
+  function submit_local_form() {
+    // Launch acknowledge request and bailout this modal view
+    do_acknowledge("{{name}}", $('#reason').val(), '{{user.get_name()}}');
     start_refresh();
-		$('#modal').modal('hide');
-	}
+    $('#modal').modal('hide');
+  }
 </script>
 
 <div class="modal-dialog">
-	<div class="modal-content">
-		<div class="modal-header">
-			<a class="close" data-dismiss="modal">×</a>
-			<h3>Acknowledge {{name}}</h3>
-		</div>
+  <div class="modal-content">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3>Acknowledge {{name}}</h3>
+    </div>
 
-		<div class="modal-body">
-			<form name="input_form" role="form">
+    <div class="modal-body">
+      <form name="input_form" role="form">
         <div class="form-group">
-          <label>Reason</label>
-          <textarea type="textarea" name="reason" id="reason" autofocus="" class="input-group col-sm-offset-1 col-sm-10" rows="5" placeholder="Reason..."/>
+          <textarea name="reason" id="reason" class="form-control" rows="5" placeholder="Reason…">Acknowledged from WebUI by {{user.get_name()}}.</textarea>
         </div>
         
         <a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
-			</form>
-		</div>
-	</div>
+      </form>
+    </div>
+  </div>
 </div>

--- a/module/plugins/forms/views/form_comment.tpl
+++ b/module/plugins/forms/views/form_comment.tpl
@@ -1,29 +1,27 @@
 <script type="text/javascript">
-	function submit_local_form() {
-		// Launch acknowledge request and bailout this modal view
-		add_comment("{{name}}", '{{user.get_name()}}', $('#comment').val());
+  function submit_local_form() {
+    // Launch acknowledge request and bailout this modal view
+    add_comment("{{name}}", '{{user.get_name()}}', $('#comment').val());
     start_refresh();
-		$('#modal').modal('hide');
-	}
+    $('#modal').modal('hide');
+  }
 </script>
 
-
 <div class="modal-dialog">
-	<div class="modal-content">
-		<div class="modal-header">
-			<a class="close" data-dismiss="modal">×</a>
-			<h3>Add a comment for {{name}}</h3>
-		</div>
+  <div class="modal-content">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3>Add a comment for {{name}}</h3>
+    </div>
 
-		<div class="modal-body">
-			<form name="input_form" role="form">
+    <div class="modal-body">
+      <form name="input_form" role="form">
         <div class="form-group">
-          <label>Comment</label>
-          <textarea type="textarea" name='comment' id='comment' class="input-group col-sm-offset-1 col-sm-10" rows="5" placeholder="Comment..."/>
+          <textarea name="reason" id="reason" class="form-control" rows="5" placeholder="Comment…"></textarea>
         </div>
         
-        <div class="col-sm-12" style="margin-top: 10px;"><a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a></div>
-			</form>
-		</div>
-	</div>
+        <a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
+      </form>
+    </div>
+  </div>
 </div>

--- a/module/plugins/forms/views/form_comment_delete.tpl
+++ b/module/plugins/forms/views/form_comment_delete.tpl
@@ -20,25 +20,21 @@
 	}
 </script>
 
-
 <div class="modal-dialog">
-	<div class="modal-content">
-		<div class="modal-header">
-			<a class="close" data-dismiss="modal">×</a>
-			<h3>Deletion confirm</h3>
-		</div>
+  <div class="modal-content">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3>Confirm comment(s) deletion</h3>
+    </div>
 
-		<div class="modal-body">
-			<form name="input_form" role="form">
-				<div class="form-group">
-          <label>Comment</label>
-          <textarea type="textarea" name='comment' id='comment' class="input-group col-sm-offset-1 col-sm-10" rows="5" placeholder="Comment..."/>
-					<label class="col-sm-12 control-label text-center">Are you sure you want to delete all comments ?</label>
-          <br/>
-				</div>
+    <div class="modal-body">
+      <form name="input_form" role="form">
+        <div class="form-group">
+          <textarea name="reason" id="reason" class="form-control" rows="5" placeholder="Comment…">All comments deleted from WebUI by {{user.get_name()}}.</textarea>
+        </div>
         
-        <div class="col-sm-12" style="margin-top: 10px;"><a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Delete</a></div>
-			</form>
-		</div>
-	</div>
+        <a href="javascript:submit_local_form();" class="btn btn-danger btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
+      </form>
+    </div>
+  </div>
 </div>

--- a/module/plugins/forms/views/form_downtime.tpl
+++ b/module/plugins/forms/views/form_downtime.tpl
@@ -23,7 +23,7 @@
             '1 month':       [moment(), moment().add('month', 1)],
          },
          format: 'YYYY-MM-DD HH:mm',
-         separator: ' to ',
+         separator: '   to   ',
          minDate: moment(),
          //dateLimit: moment(),
          startDate: moment(),
@@ -42,7 +42,7 @@
       );
     
       // Default date range is one hour from now ...
-      $('#dtr_downtime').val(downtime_start.format('YYYY-MM-DD HH:mm') + ' to ' +  downtime_stop.format('YYYY-MM-DD HH:mm'));
+      $('#dtr_downtime').val(downtime_start.format('YYYY-MM-DD HH:mm') + '   to   ' +  downtime_stop.format('YYYY-MM-DD HH:mm'));
     
       // Update dates on apply button ...
       $('#dtr_downtime').on('apply.daterangepicker', function(ev, picker) {
@@ -61,16 +61,15 @@
       <div class="modal-body">
          <form name="input_form" role="form">
             <div class="form-group">
-               <label for="dtr_downtime">Downtime date range</label>
-               <div class="input-group col-sm-offset-1 col-sm-10">
+               <!--<label for="dtr_downtime">Downtime date range</label>-->
+               <div class="input-group">
                   <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                   <input type="text" name="dtr_downtime" id="dtr_downtime" class="form-control" />
                </div>
             </div>
 
             <div class="form-group">
-               <label>Downtime comment</label>
-               <textarea type="textarea" name='reason' id='reason' class="form-control-static input-group col-sm-offset-1 col-sm-10" rows=5 placeholder="Reason..."/>
+              <textarea name="reason" id="reason" class="form-control" rows="5" placeholder="Downtime comment…"></textarea>
             </div>
            
             <a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
@@ -78,3 +77,5 @@
       </div>
    </div>
 </div>
+
+

--- a/module/plugins/forms/views/form_downtime_delete.tpl
+++ b/module/plugins/forms/views/form_downtime_delete.tpl
@@ -20,25 +20,21 @@
 	}
 </script>
 
-
 <div class="modal-dialog">
-	<div class="modal-content">
-		<div class="modal-header">
-			<a class="close" data-dismiss="modal">×</a>
-			<h3>Deletion confirm</h3>
-		</div>
+  <div class="modal-content">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3>Confirm downtime(s) deletion</h3>
+    </div>
 
-		<div class="modal-body">
-			<form name="input_form" class="form-horizontal" role="form">
-				<div class="form-group">
-          <label>Comment</label>
-          <textarea type="textarea" name='comment' id='comment' class="input-group col-sm-offset-1 col-sm-10" rows="5" placeholder="Comment..."/>
-					<label class="col-sm-12 control-label text-center">Are you sure you want to delete all downtimes ?</label>
-          <br/>
-				</div>
+    <div class="modal-body">
+      <form name="input_form" role="form">
+        <div class="form-group">
+          <textarea name="reason" id="reason" class="form-control" rows="5" placeholder="Comment…">All dowtimes deleted from WebUI by {{user.get_name()}}.</textarea>
+        </div>
         
-        <div class="col-sm-12" style="margin-top: 10px;"><a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Delete</a></div>
-			</form>
-		</div>
-	</div>
+        <a href="javascript:submit_local_form();" class="btn btn-danger btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
+      </form>
+    </div>
+  </div>
 </div>

--- a/module/plugins/forms/views/form_submit_check.tpl
+++ b/module/plugins/forms/views/form_submit_check.tpl
@@ -1,51 +1,53 @@
 <script type="text/javascript">
-	function submit_local_form() {
-		submit_check("{{name}}", $('#return_code').val(), $('#output').val());
-		$('#modal').modal('hide')
-	}
+  function submit_local_form() {
+    submit_check("{{name}}", $('#return_code').val(), $('#output').val());
+    $('#modal').modal('hide')
+  }
 </script>
 
 
 <div class="modal-dialog">
-	<div class="modal-content">
-		<div class="modal-header">
-			<a class="close" data-dismiss="modal">×</a>
-			<h3>Submit check for {{name}}</h3>
-		</div>
-		
-		<div class="modal-body">
-      <div class="row">
-        <form name="input_form" role="form">
-          <div class="form-group">
-            <label class="col-sm-2 control-label">Status</label>
-            <select id='return_code' name='return_code'>
-            %if obj_type == 'host':
+  <div class="modal-content">
+    <div class="modal-header">
+      <a class="close" data-dismiss="modal">×</a>
+      <h3>Submit check for {{name}}</h3>
+    </div>
+    
+    <div class="modal-body">
+      <form class="form-horizontal" name="input_form" role="form">
+        <div class="form-group">
+          <label for="return_code" class="col-sm-2 control-label">Status</label>
+          <div class="col-sm-10">
+            <select class="form-control" id='return_code' name='return_code'>
+              %if obj_type == 'host':
               <option value='0'>UP</option>
               <option value='1'>DOWN</option>
               <option value='2'>UNREACHABLE</option>
-            %else:
+              %else:
               <option value='0'>OK</option>
               <option value='1'>WARNING</option>
               <option value='2'>CRITICAL</option>
               <option value='3'>UNKNOWN</option>
-            %end
+              %end
             </select>
           </div>
+        </div>
 
-          <div class="form-group">
-            <label class="col-sm-2 control-label">Output</label>
-            <input class="col-sm-9" type="text" id="output" name="output" placeholder="Check output...">
+        <div class="form-group">
+          <label for="output" class="col-sm-2 control-label">Output</label>
+          <div class="col-sm-10">
+            <input class="form-control" type="text" id="output" name="output" placeholder="Check output…">
           </div>
+        </div>
 
-          <!--
-          <div class="form-group">
-            <label class="col-sm-2 control-label">Perfdata</label>
-            <input type="text" name='perfdata' class="col-sm-9" placeholder="Perfdata...">
-          </div>
-          -->
-          <div class="col-sm-12" style="margin-top: 10px;"><a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a></div>
-        </form>
-      </div>
-		</div>
-	</div>
+        <!--
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Perfdata</label>
+          <input type="text" name='perfdata' class="col-sm-9" placeholder="Perfdata...">
+        </div>
+        -->
+        <a href="javascript:submit_local_form();" class="btn btn-primary btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
+      </form>
+    </div>
+  </div>
 </div>

--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -508,21 +508,45 @@
                      %if actions_allowed:
                      <td align="right">
                        <div class="btn-group" role="group" aria-label="...">
+                         %if pb.event_handler:
                          <button type="button" class="btn btn-default btn-xs" title="Try to fix (launch event handler if defined)" onClick="try_to_fix_one('{{ pb.get_full_name() }}');">
                            <i class="fa fa-magic"></i> Try to fix
                          </button>
+                         %end
                          <button type="button" class="btn btn-default btn-xs" title="Launch the check command " onClick="recheck_now_one('{{ pb.get_full_name() }}');">
                            <i class="fa fa-refresh"></i> Refresh
                          </button>
                          <button type="button" class="btn btn-default btn-xs" title="Force service to be considered as Ok" onClick="submit_check_ok_one('{{ pb.get_full_name() }}', '{{ user.get_name() }}');">
                            <i class="fa fa-share"></i> OK
                          </button>
-                         <button type="button" class="btn btn-default btn-xs" title="Acknowledge the problem" onClick="acknowledge_one('{{ pb.get_full_name() }}', '{{ user.get_name() }}');">
+                         <button type="button" id="btn-acknowledge-{{helper.get_html_id(pb)}}" class="btn btn-default btn-xs" title="Acknowledge the problem">
                            <i class="fa fa-check"></i> ACK
                          </button>
-                         <button type="button" class="btn btn-default btn-xs" title="Schedule a one day downtime for the problem" onClick="downtime_one('{{ pb.get_full_name() }}', '{{ user.get_name() }}');">
+                         <script>
+                           $('button[id="btn-acknowledge-{{helper.get_html_id(pb)}}"]').click(function () {
+                             stop_refresh();
+                             $('#modal').modal({
+                               keyboard: true,
+                               show: true,
+                               backdrop: 'static',
+                               remote: "/forms/acknowledge/{{helper.get_uri_name(pb)}}"
+                             });
+                           });
+                         </script>
+                         <button type="button" id="btn-downtime-{{helper.get_html_id(pb)}}" class="btn btn-default btn-xs" title="Schedule a one day downtime for the problem">
                            <i class="fa fa-ambulance"></i> Downtime
                          </button>
+                         <script>
+                           $('button[id="btn-downtime-{{helper.get_html_id(pb)}}"]').click(function () {
+                             stop_refresh();
+                             $('#modal').modal({
+                               keyboard: true,
+                               show: true,
+                               backdrop: 'static',
+                               remote: "/forms/downtime/{{helper.get_uri_name(pb)}}"
+                             });
+                           });
+                         </script>
                          <button type="button" class="btn btn-default btn-xs" title="Ignore checks for the service (disable checks, notifications, event handlers and force Ok)" onClick="remove_one('{{ pb.get_full_name() }}', '{{ user.get_name() }}');">
                            <i class="fa fa-eraser"></i> Remove
                          </button>


### PR DESCRIPTION
@mohierf I did as you ask in https://github.com/shinken-monitoring/mod-webui/pull/144 and I copy the action buttons of the eltview. In this PR:
- "Try to fix" does not display if there is no `event_handler` on the problem
- "Acknowledge" and "Downtime" opens a form to ask the user to customize the comment and the downtime period.
- I cleanup and debug the /forms views, because there was some HTML and BS3 bugs.

I also take the liberty to add "*~" in the .gitignore. I could have done another PR for this, but it was in my branch, so… If you disagree with this commit, just tell me and I will remove it from the PR.