### PR TITLE
Cleanup

### DIFF
--- a/module/htdocs/css/shinken-layout.css
+++ b/module/htdocs/css/shinken-layout.css
@@ -247,7 +247,11 @@ ul.navbar-right a.quickinfo{
   color: #49afcd !important;
 }
 
-.font-greyed, .font-ack, .font-downtime {
+.font-ack, .font-downtime {
+  color: #777 !important;
+}
+
+.font-greyed {
   color: #ccc !important;
 }
 

--- a/module/plugins/groups/views/hosts-groups-overview.tpl
+++ b/module/plugins/groups/views/hosts-groups-overview.tpl
@@ -4,56 +4,33 @@
 
 %from shinken.misc.filter import only_related_to
 
-%nHosts=0
-%hosts=app.get_hosts(user)
-%hUp=hDown=hUnreachable=hPending=hUnknown=0
-%pctUp=pctDown=pctUnreachable=pctPending=pctUnknown=0
-%for h in hosts:
-   %nHosts=nHosts+1
-   %if h.state == 'UP':
-      %hUp=hUp+1
-   %elif h.state == 'DOWN':
-      %hDown=hDown+1
-   %elif h.state == 'UNREACHABLE':
-      %hUnreachable=hUnreachable+1
-   %elif h.state == 'PENDING':
-      %hPending=hPending+1
-   %else:
-      %hUnknown=hUnknown+1
-   %end
-%end
-%if nHosts != 0:
-   %pctUp            = round(100.0 * hUp / nHosts, 2)
-   %pctDown          = round(100.0 * hDown / nHosts, 2)
-   %pctUnreachable   = round(100.0 * hUnreachable / nHosts, 2)
-   %pctPending       = round(100.0 * hPending / nHosts, 2)
-   %pctUnknown       = round(100.0 * hUnknown / nHosts, 2)
-%end
+%hosts = app.get_hosts(user)
+%h = helper.get_synthesis(hosts)['hosts']
 
 <div class="row">
    <div class="pull-left col-sm-2">
-      <span class="pull-right">Total hosts: {{len(hosts)}}</span>
+      <span class="pull-right">Total hosts: {{h['nb_elts']}}</span>
    </div>
    <div class="pull-left progress col-sm-8 no-leftpadding no-rightpadding" style="height: 25px;">
-      <div title="{{hUp}} hosts Up" class="progress-bar progress-bar-success quickinfo" role="progressbar" 
+      <div title="{{h['nb_up']}} hosts Up" class="progress-bar progress-bar-success quickinfo" role="progressbar" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctUp}}%;">{{pctUp}}% Up</div>
+         style="line-height: 25px; width: {{h['pct_up']}}%;">{{h['pct_up']}}% Up</div>
 
-      <div title="{{hDown}} hosts Down" class="progress-bar progress-bar-danger quickinfo" 
+      <div title="{{h['nb_down']}} hosts Down" class="progress-bar progress-bar-danger quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctDown}}%;">{{pctDown}}% Down</div>
+         style="line-height: 25px; width: {{h['pct_down']}}%;">{{h['pct_down']}}% Down</div>
 
-      <div title="{{hUnreachable}} hosts Unreachable" class="progress-bar progress-bar-warning quickinfo" 
+      <div title="{{h['nb_unreachable']}} hosts Unreachable" class="progress-bar progress-bar-warning quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctUnreachable}}%;">{{pctUnreachable}}% Unreachable</div>
+         style="line-height: 25px; width: {{h['pct_unreachable']}}%;">{{h['pct_unreachable']}}% Unreachable</div>
 
-      <div title="{{hPending}} hosts Pending" class="progress-bar progress-bar-info quickinfo" 
+      <div title="{{h['nb_pending']}} hosts Pending" class="progress-bar progress-bar-info quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctPending}}%;">{{pctPending}}% Pending</div>
+         style="line-height: 25px; width: {{h['pct_pending']}}%;">{{h['pct_pending']}}% Pending</div>
 
-      <div title="{{hUnknown}} hosts Unknown" class="progress-bar progress-bar-info quickinfo" 
+      <div title="{{h['nb_unknown']}} hosts Unknown" class="progress-bar progress-bar-info quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctUnknown}}%;">{{pctUnknown}}% Unknown</div>
+         style="line-height: 25px; width: {{h['pct_unknown']}}%;">{{h['pct_unknown']}}% Unknown</div>
    </div>
    <div class="pull-right col-sm-2">
       <span class="btn-group pull-right">
@@ -93,22 +70,22 @@
         <h3>All hosts</h3>
         <span class="meta">
          <span class="{{'font-up' if hUp > 0 else 'font-greyed'}}">
-            {{!helper.get_fa_icon_state(cls='host', state='up')}}
+            {{!helper.get_fa_icon_state(cls='host', state='up', disabled=(not hUp))}}
             <span class="num">{{hUp}}</span>
          </span> 
           
          <span class="{{'font-unreachable' if hUnreachable > 0 else 'font-greyed'}}">
-            {{!helper.get_fa_icon_state(cls='host', state='unreachable')}} 
+            {{!helper.get_fa_icon_state(cls='host', state='unreachable', disabled=(not hUnreachable))}} 
             <span class="num">{{hUnreachable}}</span>
          </span> 
 
          <span class="{{'font-down' if hDown > 0 else 'font-greyed'}}">
-            {{!helper.get_fa_icon_state(cls='host', state='down')}} 
+            {{!helper.get_fa_icon_state(cls='host', state='down', disabled=(not hDown))}} 
             <span class="num">{{hDown}}</span>
          </span> 
 
          <span class="{{'font-unknown' if hUnknown > 0 else 'font-greyed'}}">
-            {{!helper.get_fa_icon_state(cls='host', state='unknown')}} 
+            {{!helper.get_fa_icon_state(cls='host', state='unknown', disabled=(not hUnknown))}} 
             <span class="num">{{hUnknown}}</span>
          </span> 
         </span>
@@ -168,22 +145,22 @@
                </h3>
                <span class="meta">
                   <span class="{{'font-up' if hUp > 0 else 'font-greyed'}}">
-                     {{!helper.get_fa_icon_state(cls='host', state='up')}}
+                     {{!helper.get_fa_icon_state(cls='host', state='up', disabled=(not hUp))}}
                      <span class="num">{{hUp}}</span>
                   </span> 
                    
                   <span class="{{'font-unreachable' if hUnreachable > 0 else 'font-greyed'}}">
-                     {{!helper.get_fa_icon_state(cls='host', state='unreachable')}} 
+                     {{!helper.get_fa_icon_state(cls='host', state='unreachable', disabled=(not hUnreachable))}} 
                      <span class="num">{{hUnreachable}}</span>
                   </span> 
 
                   <span class="{{'font-down' if hDown > 0 else 'font-greyed'}}">
-                     {{!helper.get_fa_icon_state(cls='host', state='down')}} 
+                     {{!helper.get_fa_icon_state(cls='host', state='down', disabled=(not hDown))}} 
                      <span class="num">{{hDown}}</span>
                   </span> 
 
                   <span class="{{'font-unknown' if hUnknown > 0 else 'font-greyed'}}">
-                     {{!helper.get_fa_icon_state(cls='host', state='unknown')}} 
+                     {{!helper.get_fa_icon_state(cls='host', state='unknown', disabled=(not hUnknown))}} 
                      <span class="num">{{hUnknown}}</span>
                   </span> 
                </span>

--- a/module/plugins/groups/views/services-groups-overview.tpl
+++ b/module/plugins/groups/views/services-groups-overview.tpl
@@ -4,62 +4,33 @@
 
 %from shinken.misc.filter import only_related_to
 
-%nServices=0
-%services=app.get_services(user)
-%sOk=sCritical=sWarning=sPending=sUnknown=sAck=sDowntime=0
-%pctOk=pctWarning=pctCritical=pctPending=pctUnknown=0
-%for s in services:
-   %nServices=nServices+1
-   %if s.state == 'OK':
-      %sOk=sOk+1
-   %elif s.state == 'CRITICAL':
-      %sCritical=sCritical+1
-   %elif s.state == 'WARNING':
-      %sWarning=sWarning+1
-   %elif s.state == 'PENDING':
-      %sPending=sPending+1
-   %else:
-      %sUnknown=sUnknown+1
-   %end
-   %if s.problem_has_been_acknowledged:
-      %sAck=sAck+1
-   %end
-   %if s.in_scheduled_downtime:
-      %sDowntime=sDowntime+1
-   %end
-%end
-%if nServices != 0:
-   %pctOk            = round(100.0 * sOk / nServices, 2)
-   %pctCritical      = round(100.0 * sCritical / nServices, 2)
-   %pctWarning       = round(100.0 * sWarning / nServices, 2)
-   %pctPending       = round(100.0 * sPending / nServices, 2)
-   %pctUnknown       = round(100.0 * sUnknown / nServices, 2)
-%end
+%services = app.get_services(user)
+%s = helper.get_synthesis(services)['services']
 
 <div class="row">
    <div class="pull-left col-sm-2">
-      <span class="pull-right">Total services: {{len(services)}}</span>
+      <span class="pull-right">Total services: {{s['nb_elts']}}</span>
    </div>
    <div class="pull-left progress col-sm-8 no-leftpadding no-rightpadding" style="height: 25px;">
-      <div title="{{sOk}} services Ok" class="progress-bar progress-bar-success quickinfo" role="progressbar" 
+      <div title="{{s['nb_ok']}} services Ok" class="progress-bar progress-bar-success quickinfo" role="progressbar" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctOk}}%;">{{pctOk}}% Ok</div>
+         style="line-height: 25px; width: {{s['pct_ok']}}%;">{{s['pct_ok']}}% Ok</div>
 
-      <div title="{{sCritical}} services Critical" class="progress-bar progress-bar-danger quickinfo" 
+      <div title="{{s['nb_critical']}} services Critical" class="progress-bar progress-bar-danger quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctCritical}}%;">{{pctCritical}}% Critical</div>
+         style="line-height: 25px; width: {{s['pct_critical']}}%;">{{s['pct_critical']}}% Critical</div>
 
-      <div title="{{sWarning}} services Warning" class="progress-bar progress-bar-warning quickinfo" 
+      <div title="{{s['nb_warning']}} services Warning" class="progress-bar progress-bar-warning quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctWarning}}%;">{{pctWarning}}% Warning</div>
+         style="line-height: 25px; width: {{s['pct_warning']}}%;">{{s['pct_warning']}}% Warning</div>
 
-      <div title="{{sPending}} services Pending" class="progress-bar progress-bar-info quickinfo" 
+      <div title="{{s['nb_pending']}} services Pending" class="progress-bar progress-bar-info quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctPending}}%;">{{pctPending}}% Pending</div>
+         style="line-height: 25px; width: {{s['pct_pending']}}%;">{{s['pct_pending']}}% Pending</div>
 
-      <div title="{{sUnknown}} services Unknown" class="progress-bar progress-bar-info quickinfo" 
+      <div title="{{s['nb_unknown']}} services Unknown" class="progress-bar progress-bar-info quickinfo" 
          data-toggle="tooltip" data-placement="bottom" 
-         style="line-height: 25px; width: {{pctUnknown}}%;">{{pctUnknown}}% Unknown</div>
+         style="line-height: 25px; width: {{s['pct_unknown']}}%;">{{s['pct_unknown']}}% Unknown</div>
    </div>
    <div class="pull-right col-sm-2">
       <span class="btn-group pull-right">

--- a/module/plugins/problems/problems.py
+++ b/module/plugins/problems/problems.py
@@ -73,9 +73,9 @@ def get_all():
         end = start + step
 
     navi = app.helper.get_navi(total, start, step=step)
-    items = items[start:end]
+    pbs = items[start:end]
 
-    return {'app': app, 'pbs': items, 'user': user, 'navi': navi, 'search_string': search, 'bookmarks': app.get_user_bookmarks(user), 'bookmarksro': app.get_common_bookmarks(), 'sound': sound_pref, 'elts_per_page': elts_per_page}
+    return {'app': app, 'pbs': pbs, 'all_pbs': items, 'user': user, 'navi': navi, 'search_string': search, 'bookmarks': app.get_user_bookmarks(user), 'bookmarksro': app.get_common_bookmarks(), 'sound': sound_pref, 'elts_per_page': elts_per_page}
 
 
 def get_pbs_widget():

--- a/module/plugins/problems/problems.py
+++ b/module/plugins/problems/problems.py
@@ -23,43 +23,26 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 
-from shinken.misc.filter  import only_related_to
+from shinken.misc.filter import only_related_to
 from shinken.misc.sorter import hst_srv_sort
-from shinken.objects.service import Service
 from shinken.log import logger
 
-### Will be populated by the UI with it's own value
+# Will be populated by the UI with it's own value
 app = None
 
 import time
 import re
-import json
 
 
-# Our page
 def get_page():
     app.bottle.redirect("/all?search=isnot:UP isnot:OK isnot:PENDING ack:false downtime:false")
 
 
-# Our page
 def get_all():
-    return get_view()
-
-
-# Our View code. We will get different data from all and /problems
-# but it's mainly filtering changes
-def get_view(default_search=""):
     user = app.check_user_authentication()
 
     # Fetch elements per page preference for user, default is 25
     elts_per_page = app.get_user_preference(user, 'elts_per_page', 25)
-
-    # Fetch toolbar preference for user, default is 'show'
-    toolbar_pref = app.get_user_preference(user, 'toolbar', 'show')
-    toolbar = app.request.GET.get('toolbar', '')
-    if toolbar != toolbar_pref and toolbar in ['show', 'hide']:
-        app.set_user_preference(user, 'toolbar', toolbar)
-        toolbar_pref = toolbar
 
     # Fetch sound preference for user, default is 'no'
     sound_pref = app.get_user_preference(user, 'sound', 'yes' if app.play_sound else 'no')
@@ -73,178 +56,8 @@ def get_view(default_search=""):
     start = int(app.request.GET.get('start', '0'))
     end = int(app.request.GET.get('end', start + step))
 
-    items = app.get_all_hosts_and_services(user, get_impacts=False)
-
-    logger.debug("[%s] problems", app.name)
-    for i in items:
-        logger.debug("[%s] problems, item: %s", app.name, i.get_full_name())
-        
-    # Filter with the user interests
-    # my_items = only_related_to(items, user)
-    my_items = items
-
-    # Check for related host contacts
-    if not user.is_admin:
-      for i in items:
-        if isinstance(i,Service):
-          if user in i.host.contacts:
-            my_items.append(i)
-            continue
-
-    items = my_items
-    logger.debug("[%s] problems after user filtering", app.name)
-    for i in items:
-        logger.debug("[%s] problems, item: %s", app.name, i.get_full_name())
-        
-
-    # We will keep a trace of our filters
-    # :TODO:maethor:150614: probably useless
-    filters = {}
-    ts = ['hst_srv', 'hg', 'realm', 'htag', 'stag', 'ack', 'downtime', 'crit', 'is', 'isnot']
-    for t in ts:
-        filters[t] = []
-
-    search = app.request.GET.getall('search') or default_search
-
-    if isinstance(search, basestring):
-        search = [search]
-
-    search = [s for _s in search for s in _s.split(' ')]
-
-
-    # Ok, if needed, apply the search filter
-    for s in search:
-        s = s.strip()
-        if not s:
-            continue
-
-        logger.debug("[%s] problems, searching for: %s in %d items", app.name, s, len(items))
-
-        elts = s.split(':', 1)
-        t = 'hst_srv'
-        if len(elts) > 1:
-            t = elts[0]
-            s = elts[1]
-
-        logger.debug("[%s] problems, searching for type %s, pattern: %s", app.name, t, s)
-        if not t in filters:
-            filters[t] = []
-        filters[t].append(s)
-
-        if t == 'hst_srv':
-            # We compile the pattern
-            pat = re.compile(s, re.IGNORECASE)
-            new_items = []
-            for i in items:
-                if pat.search(i.get_full_name()):
-                    new_items.append(i)
-                else:
-                    for j in (i.impacts + i.source_problems):
-                        if pat.search(j.get_full_name()):
-                            new_items.append(i)
-
-            items = new_items
-
-        if (t == 'hg' or t == 'hgroup') and s != 'all':
-            group = app.datamgr.get_hostgroup(s)
-            items = [i for i in items if group in i.get_hostgroups()]
-
-        if (t == 'sg' or t == 'sgroup') and s != 'all':
-            group = app.datamgr.get_servicegroup(s)
-            items = [i for i in items if group in i.get_servicegroups()]
-
-        if t == 'realm':
-            r = app.datamgr.get_realm(s)
-            items = [i for i in items if i.get_realm() == r]
-
-        if t == 'htag' and s != 'all':
-            items = [i for i in items if s in i.get_host_tags()]
-
-        if t == 'stag' and s != 'all':
-            items = [i for i in items if i.__class__.my_type == 'service' and s in i.get_service_tags()]
-
-        if t == 'type':
-            items = [i for i in items if i.__class__.my_type == s]
-
-        if t == 'bp' or t == 'bi':
-            if s.startswith('>='):
-                items = [i for i in items if i.business_impact >= int(s[2:])]
-            elif s.startswith('<='):
-                items = [i for i in items if i.business_impact <= int(s[2:])]
-            elif s.startswith('>'):
-                items = [i for i in items if i.business_impact > int(s[1:])]
-            elif s.startswith('<'):
-                items = [i for i in items if i.business_impact < int(s[1:])]
-            else:
-                if s.startswith('='):
-                    s = s[1:]
-                items = [i for i in items if i.business_impact == int(s)]
-
-        if t == 'ack':
-            if s == 'false' or s == 'no':
-                # First look for hosts, so ok for services, but remove problem_has_been_acknowledged elements
-                items = [i for i in items if i.__class__.my_type == 'service' or not i.problem_has_been_acknowledged]
-                # Now ok for hosts, but look for services, and service hosts
-                items = [i for i in items if i.__class__.my_type == 'host' or (not i.problem_has_been_acknowledged and not i.host.problem_has_been_acknowledged)]
-            if s == 'true' or s == 'yes':
-                # First look for hosts, so ok for services, but remove problem_has_been_acknowledged elements
-                items = [i for i in items if i.__class__.my_type == 'service' or i.problem_has_been_acknowledged]
-                # Now ok for hosts, but look for services, and service hosts
-                items = [i for i in items if i.__class__.my_type == 'host' or (i.problem_has_been_acknowledged or i.host.problem_has_been_acknowledged)]
-
-        if t == 'downtime':
-            if s == 'false' or s == 'no':
-                # First look for hosts, so ok for services, but remove problem_has_been_acknowledged elements
-                items = [i for i in items if i.__class__.my_type == 'service' or not i.in_scheduled_downtime]
-                # Now ok for hosts, but look for services, and service hosts
-                items = [i for i in items if i.__class__.my_type == 'host' or (not i.in_scheduled_downtime and not i.host.in_scheduled_downtime)]
-            if s == 'true' or s == 'yes':
-                # First look for hosts, so ok for services, but remove problem_has_been_acknowledged elements
-                items = [i for i in items if i.__class__.my_type == 'service' or i.in_scheduled_downtime]
-                # Now ok for hosts, but look for services, and service hosts
-                items = [i for i in items if i.__class__.my_type == 'host' or (i.in_scheduled_downtime or i.host.in_scheduled_downtime)]
-
-        if t == 'crit':
-            items = [i for i in items if (i.__class__.my_type == 'service' and i.state_id == 2) or (i.__class__.my_type == 'host' and i.state_id == 1)]
-
-        # :TODO:maethor:150604: Would be nice to have is:downtime and is:ack, but I don't want to duplicate code.
-        if t == 'is':
-            if len(s) == 1:
-                items = [i for i in items if i.state_id == int(s)]
-            else:
-                items = [i for i in items if i.state == s.upper()]
-
-        if t == 'isnot':
-            if len(s) == 1:
-                items = [i for i in items if i.state_id != int(s)]
-            else:
-                items = [i for i in items if i.state != s.upper()]
-
-
-
-        logger.debug("[%s] problems, found %d elements for type %s, pattern: %s", app.name, len(items), t, s)
-
-
-    # :TODO:maethor:150604: Cleanup this
-    # If we are in the /problems and we do not have an ack filter
-    # we apply by default the ack:false one
-#    if page == 'problems' and len(filters['ack']) == 0:
-#        # First look for hosts, so ok for services, but remove problem_has_been_acknowledged elements
-#        items = [i for i in items if i.__class__.my_type == 'service' or not i.problem_has_been_acknowledged]
-#        # Now ok for hosts, but look for services, and service hosts
-#        items = [i for i in items if i.__class__.my_type == 'host' or (not i.problem_has_been_acknowledged and not i.host.problem_has_been_acknowledged)]
-
-    # If we are in the /problems and we do not have an downtime filter
-    # we apply by default the downtime:false one
-#    if page == 'problems' and len(filters['downtime']) == 0:
-#        # First look for hosts, so ok for services, but remove problem_has_been_acknowledged elements
-#        items = [i for i in items if i.__class__.my_type == 'service' or not i.in_scheduled_downtime]
-#        # Now ok for hosts, but look for services, and service hosts
-#        items = [i for i in items if i.__class__.my_type == 'host' or (not i.in_scheduled_downtime and not i.host.in_scheduled_downtime)]
-
-    logger.debug("[%s] problems after search filtering", app.name)
-    for i in items:
-        logger.debug("[%s] problems, item: %s, %d, %d", app.name, i.get_full_name(), i.business_impact, i.state_id)
+    search = ' '.join(app.request.GET.getall('search')) or ""
+    items = app.search_hosts_and_services(search, user, get_impacts=False)
 
     # Now sort it!
     items.sort(hst_srv_sort)
@@ -262,10 +75,9 @@ def get_view(default_search=""):
     navi = app.helper.get_navi(total, start, step=step)
     items = items[start:end]
 
-    return {'app': app, 'pbs': items, 'user': user, 'navi': navi, 'search_string': ' '.join(search), 'filters': filters, 'bookmarks': app.get_user_bookmarks(user), 'bookmarksro': app.get_common_bookmarks(), 'toolbar': toolbar_pref, 'sound': sound_pref, 'elts_per_page': elts_per_page }
+    return {'app': app, 'pbs': items, 'user': user, 'navi': navi, 'search_string': search, 'bookmarks': app.get_user_bookmarks(user), 'bookmarksro': app.get_common_bookmarks(), 'sound': sound_pref, 'elts_per_page': elts_per_page}
 
 
-# Our page
 def get_pbs_widget():
     user = app.check_user_authentication()
 
@@ -323,7 +135,6 @@ def get_pbs_widget():
             }
 
 
-# Our page
 def get_last_errors_widget():
     user = app.check_user_authentication()
 

--- a/module/plugins/problems/views/_problems_synthesis.tpl
+++ b/module/plugins/problems/views/_problems_synthesis.tpl
@@ -1,58 +1,8 @@
 <!-- Problems synthesis -->
 
-%hosts = [i for i in pbs if i.__class__.my_type == 'host']
-%nHosts = len(hosts)
-%hUp = len([i for i in hosts if i.state == 'UP'])
-%hDown = len([i for i in hosts if i.state == 'DOWN'])
-%hUnreachable = len([i for i in hosts if i.state == 'UNREACHABLE'])
-%hPending = len([i for i in hosts if i.state == 'PENDING'])
-%hUnknown = nHosts - hUp - hDown - hUnreachable - hPending
-%hAck = len([i for i in hosts if i.problem_has_been_acknowledged])
-%hDowntime = len([i for i in hosts if i.in_scheduled_downtime])
-%pctHUp           = 0
-%pctHDown         = 0
-%pctHUnreachable  = 0
-%pctHPending      = 0
-%pctHUnknown      = 0
-%pctHAck          = 0
-%pctHDowntime     = 0
-
-%if hosts:
-  %pctHUp           = round(100.0 * hUp / nHosts, 2)
-  %pctHDown         = round(100.0 * hDown / nHosts, 2)
-  %pctHUnreachable  = round(100.0 * hUnreachable / nHosts, 2)
-  %pctHPending      = round(100.0 * hPending / nHosts, 2)
-  %pctHUnknown      = round(100.0 * hUnknown / nHosts, 2)
-  %pctHAck          = round(100.0 * hAck / nHosts, 2)
-  %pctHDowntime     = round(100.0 * hDowntime / nHosts, 2)
-%end
-
-%services = [i for i in pbs if i.__class__.my_type == 'service']
-%nServices = len(services)
-%sOk = len([i for i in services if i.state == 'OK'])
-%sCritical = len([i for i in services if i.state == 'CRITICAL'])
-%sWarning = len([i for i in services if i.state == 'WARNING'])
-%sPending = len([i for i in services if i.state == 'PENDING'])
-%sUnknown = nServices - sOk - sCritical - sWarning - sPending
-%sAck = len([i for i in services if i.problem_has_been_acknowledged])
-%sDowntime = len([i for i in services if i.in_scheduled_downtime])
-%pctSOk           = 0
-%pctSCritical     = 0
-%pctSWarning      = 0
-%pctSPending      = 0
-%pctSUnknown      = 0
-%pctSAck          = 0
-%pctSDowntime     = 0
-
-%if services:
-  %pctSOk           = round(100.0 * sOk / nServices, 2)
-  %pctSCritical     = round(100.0 * sCritical / nServices, 2)
-  %pctSWarning      = round(100.0 * sWarning / nServices, 2)
-  %pctSPending      = round(100.0 * sPending / nServices, 2)
-  %pctSUnknown      = round(100.0 * sUnknown / nServices, 2)
-  %pctSAck          = round(100.0 * sAck / nServices, 2)
-  %pctSDowntime     = round(100.0 * sDowntime / nServices, 2)
-%end
+%synthesis = helper.get_synthesis(all_pbs)
+%s = synthesis['services']
+%h = synthesis['hosts']
 
 <div class="panel panel-default">
    <div class="panel-body">
@@ -61,85 +11,29 @@
            %if 'type:service' not in search_string:
             <tr>
                <td>
-               <b>{{nHosts}} hosts:&nbsp;</b> 
+               <b>{{h['nb_elts']}} hosts:&nbsp;</b> 
                </td>
              
-               <td><span title="Up" class="{{'font-up' if hUp > 0 else 'font-greyed'}}">
-               <span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-server fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{hUp}} <i>({{pctHUp}}%)</i></span>
-               </span></td>
-             
-               <td><span title="Unreachable" class="{{'font-unreachable' if hUnreachable > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-server fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{hUnreachable}} <i>({{pctHUnreachable}}%)</i></span>
-               </span></td>
-
-               <td><span title="Down" class="{{'font-down' if hDown > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-server fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{hDown}} <i>({{pctHDown}}%)</i></span>
-               </span></td>
-
-               <td><span title="Pending" class="{{'font-pending' if hPending > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-server fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{hPending}} <i>({{pctHPending}}%)</i></span>
-               </span></td>
-
-               <td><span title="Unknown" class="{{'font-unknown' if hUnknown > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-server fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{hUnknown}} <i>({{pctHUnknown}}%)</i></span>
-               </span></td>
-
-               <td><span title="Acknowledged" class="{{'font-ack' if hAck > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-check fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{hAck}} <i>({{pctHAck}}%)</i></span>
-               </span></td>
-
-               <td><span title="In scheduled downtime" class="{{'font-downtime' if hDowntime > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-ambulance fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{hDowntime}} <i>({{pctHDowntime}}%)</i></span>
-               </span></td>
+               %for state in 'up', 'unreachable', 'down', 'pending', 'unknown', 'ack', 'downtime':
+               <td>
+                 %label = "%s <i>(%s%%)</i>" % (h['nb_' + state], h['pct_' + state])
+                 {{!helper.get_fa_icon_state_and_label(cls='host', state=state, label=label, disabled=(not h['nb_' + state]))}}
+               </td>
+               %end
             </tr>
             %end
             %if 'type:host' not in search_string:
             <tr>
                <td>
-                  <b>{{nServices}} services:&nbsp;</b> 
+                  <b>{{s['nb_elts']}} services:&nbsp;</b> 
                </td>
           
-               <td><span title="Ok" class="{{'font-ok' if sOk > 0 else 'font-greyed'}}">
-               <span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-arrow-up fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{sOk}} <i>({{pctSOk}}%)</i></span>
-               </span></td>
-          
-               <td><span title="Warning" class="{{'font-warning' if sWarning > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-exclamation fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{sWarning}} <i>({{pctSWarning}}%)</i></span>
-               </span></td>
-
-               <td><span title="Critical" class="{{'font-critical' if sCritical > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-arrow-down fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{sCritical}} <i>({{pctSCritical}}%)</i></span>
-               </span></td>
-
-               <td><span title="Pending" class="{{'font-pending' if sPending > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-pause fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{sPending}} <i>({{pctSPending}}%)</i></span>
-               </span></td>
-
-               <td><span title="Unknown" class="{{'font-unknown' if sUnknown > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-question fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{sUnknown}} <i>({{pctSUnknown}}%)</i></span>
-               </span></td>
-
-               <td><span title="Acknowledged" class="{{'font-ack' if sAck > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-check fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{sAck}} <i>({{pctSAck}}%)</i></span>
-               </span></td>
-
-               <td><span title="In downtime" class="{{'font-downtime' if sDowntime > 0 else 'font-greyed'}}">
-               <span class="fa-stack"> <i class="fa fa-circle fa-stack-2x"></i> <i class="fa fa-ambulance fa-stack-1x fa-inverse"></i></span> 
-               <span class="num">{{sDowntime}} <i>({{pctSDowntime}}%)</i></span>
-               </span></td>
+               %for state in 'ok', 'warning', 'critical', 'pending', 'unknown', 'ack', 'downtime':
+               <td>
+                 %label = "%s <i>(%s%%)</i>" % (s['nb_' + state], s['pct_' + state])
+                 {{!helper.get_fa_icon_state_and_label(cls='service', state=state, label=label, disabled=(not s['nb_' + state]))}}
+               </td>
+               %end
             </tr>
             %end
          </tbody>

--- a/module/views/header_element.tpl
+++ b/module/views/header_element.tpl
@@ -133,9 +133,9 @@
             <li> <a href="/wall"> <span class="fa fa-th-large"></span> Wall </a> </li>
           </ul>
         </li>
-        <li> <a href="/logs"> <span class="fa fa-th-list"></span> Logs </a> </li>
+        <!--<li> <a href="/logs"> <span class="fa fa-th-list"></span> Logs </a> </li>-->
         <li> <a href="/system"> <span class="fa fa-gears"></span> System </a> </li>
-        <li> <a href="/shinken-io"> <span class="fa fa-gears"></span> Shinken IO </a> </li>
+        <!--<li> <a href="/shinken-io"> <span class="fa fa-gears"></span> Shinken IO </a> </li>-->
         <li> <a href="#"><i class="fa fa-wrench"></i> Configuration <i class="fa arrow"></i></a>
           <ul class="nav nav-second-level">
             <li> <a href="/contacts"> <span class="fa fa-users"></span> Contacts </a> </li>


### PR DESCRIPTION
This is a huge one. I will go further in the cleanup, but I'm done for tonight.

Cleanup problems.py
- Adds `search_hosts_and_services()` in module.py to share the search engine.
- Cleanup search algorithm, new keyworks: is:ack and is:downtime
- PEP8 in problems.py

Cleanup synthesis (fixes #193).
- new get_synthesis() helper
- new get_fa_icon_state_and_label() helper
- rewrite _problem_synthesis.tpl to use these function
- _problem_synthesis.tpl is now based on all the search, not only the current page.
- font-ack and font-downtime colored #777 instead of #333 (font-greyed)