### PR TITLE
fix calls to get_graph_uris to prevent KeyError

### DIFF
--- a/module/plugins/eltdetail/views/eltdetail.tpl
+++ b/module/plugins/eltdetail/views/eltdetail.tpl
@@ -1323,11 +1323,11 @@ Invalid element name
                <script>
                $('#tab_to_graphs').on('shown.bs.tab', function (e) {
                   %uris = dict()
-                  %uris['4h'] = app.get_graph_uris(elt, fourhours, now, source='')
-                  %uris['1d'] = app.get_graph_uris(elt, lastday,   now, source='')
-                  %uris['1w'] = app.get_graph_uris(elt, lastweek,  now, source='')
-                  %uris['1m'] = app.get_graph_uris(elt, lastmonth, now, source='')
-                  %uris['1y'] = app.get_graph_uris(elt, lastyear,  now, source='')
+                  %uris['4h'] = app.get_graph_uris(elt, fourhours, now)
+                  %uris['1d'] = app.get_graph_uris(elt, lastday,   now)
+                  %uris['1w'] = app.get_graph_uris(elt, lastweek,  now)
+                  %uris['1m'] = app.get_graph_uris(elt, lastmonth, now)
+                  %uris['1y'] = app.get_graph_uris(elt, lastyear,  now)
 
                   // let's create the html content for each time range
                   var element='/{{elt_type}}/{{elt.get_full_name()}}';

--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -126,7 +126,7 @@
               %# Graphs
               %import time
               %now = time.time()
-              %graphs = app.get_graph_uris(pb, now-4*3600, now, source='')
+              %graphs = app.get_graph_uris(pb, now-4*3600, now)
               %if len(graphs) > 0:
                 <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[0]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb)}}</a>
               %end


### PR DESCRIPTION
Fixing calls to the get_graph_uris function again to correct KeyError from graphite module with the empty string, alternatively the source parameter could be set to "detail". Unfortunately any string other than "detail" or "dashboard" passed into the graphite-ui module will cause a key Error in the current version. I have also submitted a pull request on the graphite-ui module to correct this and accept arbitrary strings as the source