### PR TITLE
Include long-output in problems output columns

### DIFF
--- a/module/plugins/problems/htdocs/css/problems.css
+++ b/module/plugins/problems/htdocs/css/problems.css
@@ -28,3 +28,7 @@ td .progress {
 td .ellipsis {
     white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
 }
+
+td .ellipsis > .long-output {
+    display:none;
+}

--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -75,7 +75,7 @@
     <i class="pull-right small">{{len(list(bi_pbs))}} elements</i>
     <h3 class="text-center">Business impact: {{!helper.get_business_impact_text(business_impact, text=True)}}</h3>
     
-    <table class="table table-condensed table-nowrap" style="table-layout:fixed;width:100%;">
+    <table class="table table-condensed" style="table-layout:fixed;width:100%;">
       <thead><tr>
           <th width="20px"></th>
           <th width="40px"></th>
@@ -124,12 +124,11 @@
                 <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[0]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb)}}</a>
               %end
             </div>
-            <div class="ellipsis popover-dismiss" 
-                  data-html="true" data-toggle="popover" data-trigger="hover" data-placement="left" 
-                  data-title="{{pb.get_full_name()}} check output" 
-                  data-content=" {{pb.output}}{{'<br/>'+pb.long_output if pb.long_output else ''}}"
-                  >
-             {{!helper.strip_html_output(pb.output[:app.max_output_length]) if app.allow_html_output else pb.output[:app.max_output_length]}}
+            <div class="ellipsis output">
+             {{pb.output}}
+             <div class="long-output">
+               {{pb.long_output if pb.long_output else ''}}
+             </div>
             </div>
           </td>
         </tr>

--- a/module/views/header_element.tpl
+++ b/module/views/header_element.tpl
@@ -205,6 +205,11 @@
       // Date / time
       $('.headClock .time').jclock({ format: '%H:%M:%S' });
       $('.headClock .date').jclock({ format: '%d/%m/%Y' });
+
+      $('[data-toggle="popover"]').popover({
+        html: true,
+        template: '<div class="popover img-popover"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>',
+      });
       
       // Manage refresh start/stop
       $('#header_loading').click(function (e) {


### PR DESCRIPTION
This PR reverts almost entirely 29e1f50448e2df68c5d033f8770c17568ba70211 because it was not working as I expected.

Now the long-output is included in the output columns, and shows up when we collapse out the details.

@mohierf if you don't agree, we can discuss it by email.

Related to #198
