### PR TITLE
Cleanup header_loading icon

### DIFF
--- a/module/htdocs/js/shinken-refresh.js
+++ b/module/htdocs/js/shinken-refresh.js
@@ -44,11 +44,13 @@ function postpone_refresh(){
 
 function do_refresh(){
    console.debug("Refreshing ...");
+   $('#header_loading').addClass('fa-spin');
    $.get(document.URL, {}, function(data) {
       var $response = $('<div />').html(data);
       $('#page-content').html($response.find('#page-content').html());
       $('#hosts-overall-state').html($response.find('#hosts-overall-state').html());
       $('#services-overall-state').html($response.find('#services-overall-state').html());
+      $('#header_loading').removeClass('fa-spin');
    
       // Display active tab ...
       // var hash = location.hash
@@ -98,8 +100,17 @@ function check_refresh(){
 }
 
 
+function toggle_refresh() {
+    if (refresh_stopped) {
+        start_refresh();
+    } else {
+        stop_refresh();
+    }
+}
+
 /* Someone ask us to start the refresh so the page will reload */
 function start_refresh(){
+   $('#header_loading').removeClass('font-greyed');
    refresh_stopped = false;
 }
 
@@ -107,6 +118,7 @@ function start_refresh(){
 /* Someone ask us to stop the refresh so the user will have time to
    do some things like ask actions or something like that */
 function stop_refresh(){
+   $('#header_loading').addClass('font-greyed');
    refresh_stopped = true;
 }
 

--- a/module/views/header_element.tpl
+++ b/module/views/header_element.tpl
@@ -94,16 +94,18 @@
     </li>
     
     <li>
-      <a class="quickinfo" data-original-title='Currently' href="/dashboard/currently">
+      <a class="quickinfo" data-original-title='Currently' href="/dashboard/currently" title="Currently">
          <i class="fa fa-eye"></i>
       </a>
     </li>
 
+    %if refresh:
     <li>
-       <a class="quickinfo" data-original-title='Refreshing'>
-         <i id="header_loading" class="fa fa-spinner fa-spin"></i>
+       <a class="quickinfo" data-original-title='Refreshing' title="Automatic refresh" href="javascript:toggle_refresh()">
+         <i id="header_loading" class="fa fa-refresh"></i>
        </a>
     </li>
+    %end
    
     <!-- User info -->
     <li class="dropdown user user-menu">
@@ -209,21 +211,6 @@
       $('[data-toggle="popover"]').popover({
         html: true,
         template: '<div class="popover img-popover"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>',
-      });
-      
-      // Manage refresh start/stop
-      $('#header_loading').click(function (e) {
-         e.stopPropagation();
-         
-         // Manage refresh state ...
-         $(this).each(function(){
-            if ($(this).hasClass('fa-spin')) {
-               stop_refresh();
-            } else {
-               start_refresh();
-            }
-            $(this).toggleClass('fa-spin');
-         });
       });
    });
 </script>


### PR DESCRIPTION
- Add an html title
- Use fa-refresh instead of fa-spinner (already used by flapping states)
- Spin only when the page is reloading (to avoid getting too much attention on the icon)
- Add text-greyed class when the refreshing is disable