### PR TITLE
Add opensearch

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -635,6 +635,13 @@ class Webui_broker(BaseModule, Daemon):
         def give_favicon():
             return static_file('favicon.ico', root=os.path.join(htdocs_dir, 'images'))
 
+        # And add the opensearch xml
+        @route('/opensearch.xml')
+        def give_opensearch():
+            base_url = self.request.url.replace('opensearch.xml', '')
+            response.headers['Content-Type'] = 'text/xml'
+            return template('opensearch', base_url=base_url)
+
     # --------------------------------------------------------------------------------
     # User authentication / management
     # --------------------------------------------------------------------------------

--- a/module/views/layout.tpl
+++ b/module/views/layout.tpl
@@ -83,6 +83,8 @@
       <link rel="stylesheet" type="text/css" href="/static/{{p}}">
       %end
 
+      <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Search for hosts and services in Shinken" />
+
       <!-- Scripts
       ================================================== -->
       <script src="/static/js/jquery-1.11.1.min.js"></script>

--- a/module/views/opensearch.tpl
+++ b/module/views/opensearch.tpl
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Shinken</ShortName>
+  <Description>Search for services and hosts in Shinken</Description>
+  <Tags>Shinken Monitoring</Tags>
+  <Url type="text/html" template="{{ base_url }}all?search={searchTerms}"/>
+  <Language>fr-fr</Language>
+  <Image height="16" width="16" type="image/vnd.microsoft.icon">{{ base_url }}favicon.ico</Image>
+  <Query role="example" searchTerms="web01" />
+</OpenSearchDescription>
+


### PR DESCRIPTION
This PR adds a new url: `/opensearch.xml` 

This files allows firefox to detect the search engine so the user can add it to the firefox search engines. Then, the user can configure a keyword to search for services and hosts in shinken directly from the URL bar. For instance, I run "mon test" and firefox give me my shinken web with the search "test".

I suppose it is also working on chromium.