### PR TITLE
Bugs correction on History

### DIFF
--- a/module/plugins/eltdetail/htdocs/js/eltdetail.js
+++ b/module/plugins/eltdetail/htdocs/js/eltdetail.js
@@ -173,7 +173,7 @@ function on_page_refresh() {
       
       // Loading indicator ...
       $("#inner_history").html('<i class="fa fa-spinner fa-spin fa-3x"></i> Loading history data ...');
-      $("#inner_history").load('/logs/inner/'+element, function(response, status, xhr) {
+      $("#inner_history").load('/logs/inner/'+encodeURIComponent(element), function(response, status, xhr) {
          if (status == "error") {
             $('#inner_history').html('<div class="alert alert-danger">Sorry but there was an error: ' + xhr.status + ' ' + xhr.statusText+'</div>');
          }

--- a/module/plugins/logs/views/history.tpl
+++ b/module/plugins/logs/views/history.tpl
@@ -2,25 +2,30 @@
 
 %date_format='%Y-%m-%d %H:%M:%S'
 
-<table class="table table-condensed">
-   <thead>
-      <tr>
-         <th>Time</th>
-         %if elt_type == 'host':
-         <th>Service</th>
-         %end
-         <th>Message</th>
-      </tr>
-   </thead>
-   <tbody style="font-size:x-small;">
-      %for log in records:
+%if hasattr(records,"__iter__"):
+   <table class="table table-condensed">
+      <thead>
          <tr>
-            <td>{{time.strftime(date_format, time.localtime(log['timestamp']))}}</td>
+            <th>Time</th>
             %if elt_type == 'host':
-            <td>{{log['service']}}</td>
+            <th>Service</th>
             %end
-            <td>{{log['message']}}</td>
+            <th>Message</th>
          </tr>
-      %end
-   </tbody>
-</table>
+      </thead>
+      <tbody style="font-size:x-small;">
+         %for log in records:
+            <tr>
+               <td>{{time.strftime(date_format, time.localtime(log['timestamp']))}}</td>
+               %if elt_type == 'host':
+               <td>{{log['service']}}</td>
+               %end
+               <td>{{log['message']}}</td>
+            </tr>
+         %end
+      </tbody>
+   </table>
+%else:
+   No logs found
+%end
+


### PR DESCRIPTION
This pull request deal with 2 bugs we had with history when using BS3 branch:

1/ When there is no logs in mongo, the ajax call to get history fail with a 500 errors. It's a problem with an empty object not being iterable

2/ When service description contains spaces, any text following the space is truncated on the ajax call to get history. It's an issue with `$('#...").load()` jquery method, and can by corrected with `encodeURIComponent()`