### PR TITLE
GraphWidget fix duration

### DIFF
--- a/module/plugins/graphs/views/widget_graphs.tpl
+++ b/module/plugins/graphs/views/widget_graphs.tpl
@@ -10,7 +10,7 @@
    <!-- Reduce the time range of the dashboard graph to last hour
    and specify the source as dashboard !
    -->
-   %uris = app.graphs_module.get_graph_uris(elt, duration=4*3600, source='dashboard')
+   %uris = app.graphs_module.get_graph_uris(elt, duration=duration, source='dashboard')
    %if len(uris) == 0:
       <span>No graph for this element.</span>
    %else:


### PR DESCRIPTION
Hello,

The Widget Graph is set to show always 4 hours without use the user settings.

I find a way to fix it, I test on my computer and it's work for me.