### PR TITLE
Closes #322 - Search engine is now generic available in many plugins

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -496,11 +496,13 @@ class Webui_broker(BaseModule, Daemon):
             for (f, entry) in pages.items():
                 routes = entry.get('routes', None)
                 v = entry.get('view', None)
+                name = entry.get('name', None)
                 static = entry.get('static', False)
                 widget_lst = entry.get('widget', [])
                 widget_desc = entry.get('widget_desc', None)
                 widget_name = entry.get('widget_name', None)
                 widget_picture = entry.get('widget_picture', None)
+                search_engine = entry.get('search_engine', False)
 
                 # IMPORTANT: apply VIEW BEFORE route!
                 if v:
@@ -515,7 +517,7 @@ class Webui_broker(BaseModule, Daemon):
                         # plugin page, but not for static objects
                         # so we set the lock at the function level.
                         lock_version = self.lockable_function(f)
-                        f = route(r, callback=lock_version, method=method)
+                        f = route(r, callback=lock_version, method=method, name=name, search_engine=search_engine)
 
                 # If the plugin declare a static entry, register it
                 # and remember: really static! because there is no lock
@@ -713,6 +715,10 @@ class Webui_broker(BaseModule, Daemon):
                 self.modules_manager.set_to_restart(mod)
 
         return lst
+
+
+    def get_search_string(self, default=""):
+        return self.request.query.get('search', default)
 
 
     def redirect404(self, msg="Not found"):

--- a/module/plugins/availability/availability.py
+++ b/module/plugins/availability/availability.py
@@ -101,5 +101,5 @@ def get_page():
 
 pages = {
     get_element: {'routes': ['/availability/inner/<name:path>'], 'view': 'availability-elt', 'static': True},
-    get_page: {'routes': ['/availability'], 'view': 'availability-all', 'static': True},
+    get_page: {'routes': ['/availability'], 'view': 'availability-all', 'name': 'Availabilities', 'static': True, 'search_engine': True},
 }

--- a/module/plugins/minemap/minemap.py
+++ b/module/plugins/minemap/minemap.py
@@ -91,7 +91,7 @@ def show_minemap():
 
     navi = app.helper.get_navi(total, start, step=step)
 
-    return {'navi': navi, 'search_string': search, 'items': items[start:end], 'page': "minemap"}
+    return {'navi': navi, 'items': items[start:end], 'page': "minemap"}
 
 def show_minemaps():
     app.bottle.redirect("/minemap/all")
@@ -103,6 +103,6 @@ def show_minemaps():
 pages = {
     # reload_cfg: {'routes': ['/reload/minemap']},
 
-    show_minemap: {'routes': ['/minemap'], 'view': 'minemap', 'static': True},
+    show_minemap: {'routes': ['/minemap'], 'view': 'minemap', 'name': 'Minemap', 'static': True, 'search_engine': True},
     show_minemaps: {'routes': ['/minemaps'], 'view': 'minemap', 'static': True}
 }

--- a/module/plugins/minemap/views/minemap.tpl
+++ b/module/plugins/minemap/views/minemap.tpl
@@ -4,6 +4,8 @@
 
 %helper = app.helper
 
+%search_string = app.get_search_string()
+
 %# Specific content for breadrumb
 %rebase("layout", title='Minemap for hosts/services', css=['minemap/css/minemap.css'], breadcrumb=[ ['All hosts', '/minemap'] ])
 

--- a/module/plugins/problems/problems.py
+++ b/module/plugins/problems/problems.py
@@ -71,7 +71,7 @@ def get_all():
     navi = app.helper.get_navi(total, start, step=step)
     pbs = items[start:end]
 
-    return {'pbs': pbs, 'all_pbs': items, 'navi': navi, 'title': title, 'search_string': search, 'bookmarks': app.prefs_module.get_user_bookmarks(user), 'bookmarksro': app.prefs_module.get_common_bookmarks(), 'sound': sound_pref, 'elts_per_page': elts_per_page}
+    return {'pbs': pbs, 'all_pbs': items, 'navi': navi, 'title': title, 'bookmarks': app.prefs_module.get_user_bookmarks(user), 'bookmarksro': app.prefs_module.get_common_bookmarks(), 'sound': sound_pref, 'elts_per_page': elts_per_page}
 
 
 def get_pbs_widget():
@@ -158,7 +158,7 @@ Show the IT problems sorted by time
 
 pages = {
     get_page: {'routes': ['/problems'], 'view': 'problems', 'static': True},
-    get_all: {'routes': ['/all'], 'view': 'problems', 'static': True},
+    get_all: {'routes': ['/all'], 'view': 'problems', 'static': True, 'name': 'All', 'search_engine': True},
     get_pbs_widget: {'routes': ['/widget/problems'], 'view': 'widget_problems', 'static': True, 'widget': ['dashboard'], 'widget_desc': widget_desc, 'widget_name': 'problems', 'widget_picture': '/static/problems/img/widget_problems.png'},
     get_last_errors_widget: {'routes': ['/widget/last_problems'], 'view': 'widget_last_problems', 'static': True, 'widget': ['dashboard'], 'widget_desc': last_widget_desc, 'widget_name': 'last_problems', 'widget_picture': '/static/problems/img/widget_problems.png'},
 }

--- a/module/plugins/problems/views/_problems_synthesis.tpl
+++ b/module/plugins/problems/views/_problems_synthesis.tpl
@@ -1,5 +1,6 @@
 <!-- Problems synthesis -->
 
+%search_string = app.get_search_string()
 %synthesis = helper.get_synthesis(all_pbs)
 %s = synthesis['services']
 %h = synthesis['hosts']

--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -1,5 +1,6 @@
 %helper = app.helper
 %datamgr = app.datamgr
+%search_string = app.get_search_string()
 
 %rebase("layout", title=title, js=['problems/js/problems.js'], css=['problems/css/problems.css'], navi=navi, page="/all", elts_per_page=elts_per_page)
 

--- a/module/plugins/worldmap/worldmap.py
+++ b/module/plugins/worldmap/worldmap.py
@@ -102,7 +102,7 @@ def show_worldmap():
     search = app.request.query.get('search', "type:host")
 
     # So now we can just send the valid hosts to the template
-    return {'search_string': search, 'params': params,
+    return {'params': params,
             'mapId': 'hostsMap', 
             'hosts': search_hosts_with_coordinates(search, user)}
 
@@ -152,6 +152,6 @@ Show a map of all monitored hosts.
 
 # We export our properties to the webui
 pages = {
-    show_worldmap: {'routes': ['/worldmap'], 'view': 'worldmap', 'static': True},
+        show_worldmap: {'routes': ['/worldmap'], 'view': 'worldmap', 'name': 'Worldmap', 'static': True, 'search_engine': True},
     show_worldmap_widget: {'routes': ['/widget/worldmap'], 'view': 'worldmap_widget', 'static': True, 'widget': ['dashboard'], 'widget_desc': widget_desc, 'widget_name': 'worldmap', 'widget_picture': '/static/worldmap/img/widget_worldmap.png'},
 }

--- a/module/views/_filters.tpl
+++ b/module/views/_filters.tpl
@@ -1,8 +1,17 @@
-%setdefault("search_string", "")
 %setdefault("common_bookmarks", app.prefs_module.get_common_bookmarks())
 %setdefault("user_bookmarks", app.prefs_module.get_user_bookmarks(user))
 
-<form class="navbar-form navbar-left hidden-xs" method="get" action="/all">
+%if 'search_engine' in app.request.route.config and app.request.route.config['search_engine']:
+%search_action = app.request.fullpath
+%search_name = app.request.route.name
+%else:
+%search_action = '/all'
+%search_name = ''
+%end
+
+%search_string = app.get_search_string()
+
+<form class="navbar-form navbar-left hidden-xs" method="get" action="{{ search_action }}">
   <div class="dropdown form-group text-left">
     <button class="btn btn-default dropdown-toggle" type="button" id="filters_menu" data-toggle="dropdown" aria-expanded="true"><i class="fa fa-filter"></i><span class="hidden-sm hidden-xs hidden-md"> Filters</span> <span class="caret"></span></button>
     <ul class="dropdown-menu" role="menu" aria-labelledby="filters_menu">
@@ -27,7 +36,7 @@
   <div class="form-group">
     <label class="sr-only" for="search">Filter</label>
     <div class="input-group">
-      <span class="input-group-addon hidden-xs hidden-sm"><i class="fa fa-search"></i></span>
+      <span class="input-group-addon hidden-xs hidden-sm"><i class="fa fa-search"></i> {{ search_name }}</span>
       <input class="form-control" type="search" id="search" name="search" value="{{ search_string }}">
     </div>
   </div>


### PR DESCRIPTION
- All (default)
- Minemap
- Worldmap
- Availabilities

Each route can be a search engine route by simply adding `'search_engine': True` to the route dictionary vars.

What do you think @mohierf ?