### PR TITLE
Update logs.tpl

### DIFF
--- a/module/plugins/logs/views/logs.tpl
+++ b/module/plugins/logs/views/logs.tpl
@@ -120,6 +120,7 @@
      </div>
    </div>
 
+  %if hasattr(records,"__iter__"):
       <table class="table table-condensed">
          <colgroup>
             <col style="width: 10%" />
@@ -139,6 +140,10 @@
             %end
          </tbody>
       </table>
+   %else:
+      No logs found
+  %end
+
 
    <script type="text/javascript">
       $("#dtr_downtime").daterangepicker({


### PR DESCRIPTION
I still have an error 500 with this file :

"  File "/var/lib/shinken/modules/webui2/plugins/logs/views/logs.tpl", line 133, in <module>
    %for log in records:
TypeError: 'NoneType' object is not iterable"

The "records" entry is missing in this template.

I modified it with adding the same "if loop" you did in the history.tpl (including the table class).

Now I can access to System/Logs.