### PR TITLE
Avoid authentication failures after a Shinken restart when authentication is ensured by a HTTP header

### DIFF
--- a/module/plugins/login/login.py
+++ b/module/plugins/login/login.py
@@ -36,6 +36,19 @@ def get_page():
 def user_login():
     if app.request.get_cookie("user", secret=app.auth_secret):
         app.bottle.redirect("/")
+    elif app.remote_user_enable in ['1', '2']:
+        user_name=None
+        if app.remote_user_variable in app.request.headers and app.remote_user_enable == '1':
+            user_name = app.request.headers[app.remote_user_variable]
+        elif app.remote_user_variable in app.request.environ and app.remote_user_enable == '2':
+            user_name = app.request.environ[app.remote_user_variable]
+        if not user_name:
+            logger.warning("[WebUI] remote user enabled but no user name found")
+            app.bottle.redirect("/user/login")
+        c = app.datamgr.get_contact(user_name)
+        if c:
+            app.response.set_cookie('user', user_name, secret=app.auth_secret, path='/')
+            app.bottle.redirect("/")
 
     err = app.request.GET.get('error', None)
     login_text = app.login_text

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,14 +1,44 @@
 Shinken WebUI - roadmap
 =======================
 
-The version current major version (2.x) of the Shinken Web User Interface aimed at improving (or developing) the following features: 
+Next version (2.1) features of the Shinken Web User Interface (**to be discussed**): 
+## Version 2.1: 
 
-## Layout:
+
+### Layout:
+- improve mobile devices user experience (touch enabled devices, GPS aware devices, ...)
+
+### Backend:
+- use Alignak backend
+
+### Dashboard:
+- refactor widget grid ... some ideas to develop
+
+### All resources view:
+- more filtering options
+
+### Groups:
+- 
+
+### Host / service view:
+- 
+
+### Tactical overviews:
+- filtering Worldmap, Minemap, Logs, ...
+
+### System:
+- 
+
+## Version 2.0: 
+
+The current major version (2.0) of the Shinken Web User Interface aimed at improving (or developing) the following features: 
+
+### Layout:
 - clean UI layout
 - design rules for hosts/services state
 - boostrap themable layout
 
-## All / Problems view:
+### All / Problems view:
 - simple and compact user interface
 - Github like filtering system
 
@@ -21,7 +51,7 @@ The version current major version (2.x) of the Shinken Web User Interface aimed 
 
 - bookmark filters
 
-## Host / service view:
+### Host / service view:
 - clean element view
 - launch commands
 - enrich element view information: 
@@ -30,7 +60,7 @@ The version current major version (2.x) of the Shinken Web User Interface aimed 
    - history (logs)
    - availability
 
-## Tactical overviews:
+### Tactical overviews:
 - Minemap
 - Hosts/services groups
 - Hosts/services tags


### PR DESCRIPTION
Old cookies are invalid after a Shinken restart, and HTTP authentication does not work well