### PR TITLE
Fix service displaying for non admin user

### DIFF
--- a/module/datamanager.py
+++ b/module/datamanager.py
@@ -159,6 +159,11 @@ class WebUIDataManager(DataManager):
                 if contact in s.contacts:
                     return True
 
+        # May be it's a contact on service host
+        if item.__class__.my_type == 'service':
+            if contact in item.host.contacts:
+                return True
+
         # Now impacts related maybe?
         if hasattr(item, 'impacts'):
             for imp in item.impacts:


### PR DESCRIPTION
If you are standard user and contact of an host you should see faulty
services in problem list.

Cause you not necessary link all your services with contacts you will only link your contact to host and give him access on all host services.
 
This pull request add this ability.