### PR TITLE
configurable graph number on problem page

### DIFF
--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -85,8 +85,9 @@
                      %import time
                      %now = time.time()
                      %graphs = app.graphs_module.get_graph_uris(pb, duration=12*3600)
+                     %num = int(pb.customs.get('_GRAPH_NUM','0'))
                      %if len(graphs) > 0:
-                        <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[0]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb)}}</a>
+                        <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[num]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb)}}</a>
                      %end
                   </div>
                   %end


### PR DESCRIPTION
Added custom variable `_graph_num` to service description
Now you can choose which graph do you prefer to be displayed in problem page (instead of `graph[0]`).
If you omit `_graph_num`, default value 0 will be used

Example of use:
`check_cpu` which return bunch of stats (such as `user, irq, nice` etc).
default behaviour showed me random value (`softirq` in my case), but I wanted to get `user`