### PR TITLE
configurable graph number on problem page

### DIFF
--- a/module/helper.py
+++ b/module/helper.py
@@ -779,9 +779,9 @@ class Helper(object):
         return res
 
     # Get a perfometer part for html printing
-    def get_perfometer(self, elt, metric=None):
+    def get_perfometer(self, elt, metric=None, graph_num=0):
         if elt.perf_data:
-            r = get_perfometer_table_values(elt, metric=metric)
+            r = get_perfometer_table_values(elt, metric=metric, graph_num=graph_num)
             if r is None:
                 return ''
 

--- a/module/perfdata_guess.py
+++ b/module/perfdata_guess.py
@@ -33,7 +33,7 @@ from shinken.log import logger
 # lnk: link to add in this perfdata thing
 # title: text to show on it
 # metrics: list of ('html color', percent) like [('#68f', 35), ('white', 64)]
-def get_perfometer_table_values(elt, metric=None):
+def get_perfometer_table_values(elt, metric=None, graph_num=0):
     # first try to get the command name called
     cmd = elt.check_command.call.split('!')[0]
     logger.debug("[WebUI] Looking for perfometer value for element: %s, command: %s", elt.get_full_name(), cmd)
@@ -48,7 +48,7 @@ def get_perfometer_table_values(elt, metric=None):
         return f(elt, metric)
 
     try:
-        r = manage_unknown_command(elt, metric)
+        r = manage_unknown_command(elt, metric, graph_num)
     except:
         return None
     return r
@@ -146,7 +146,7 @@ def manage_check_tcp_command(elt, metric='time'):
     return {'lnk': lnk, 'metrics': metrics, 'title': title}
 
 
-def manage_unknown_command(elt, metric=None):
+def manage_unknown_command(elt, metric=None, graph_num=0):
     logger.debug("[WebUI] perfometer, manage command for: %s, metric: %s", elt.get_full_name(), metric)
     p = PerfDatas(elt.perf_data)
     if len(p) == 0:
@@ -157,16 +157,20 @@ def manage_unknown_command(elt, metric=None):
         metric = p['time']
     else:
         if metric is None:
+            metric = []
             for v in p:
                 if v.name is not None and v.value is not None:
-                    metric = v
+                    metric.append(v)
         else:
+            metric = []
             for v in p:
                 if v.name is not None and v.value is not None and v.name == metric:
-                    metric = v
+                    metric.append(v)
         
     if metric is None:
         return None
+
+    metric = metric[graph_num]
     
     name = metric.name
     value = metric.value

--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -86,8 +86,11 @@
                      %now = time.time()
                      %graphs = app.graphs_module.get_graph_uris(pb, duration=12*3600)
                      %num = int(pb.customs.get('_GRAPH_NUM','0'))
+                     %if num >= len(graphs):
+                     %  num = 0
+                     %end
                      %if len(graphs) > 0:
-                        <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[num]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb)}}</a>
+                        <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[num]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb, graph_num=num)}}</a>
                      %end
                   </div>
                   %end

--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -85,8 +85,9 @@
                      %import time
                      %now = time.time()
                      %graphs = app.graphs_module.get_graph_uris(pb, duration=12*3600)
+                     %num = int(pb.customs.get('_GRAPH_NUM','0'))
                      %if len(graphs) > 0:
-                        <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[0]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb)}}</a>
+                        <a role="button" tabindex="0" data-toggle="popover" title="{{ pb.get_full_name() }}" data-html="true" data-content="<img src='{{ graphs[num]['img_src'] }}' width='600px' height='200px'>" data-trigger="hover" data-placement="left">{{!helper.get_perfometer(pb)}}</a>
                      %end
                   </div>
                   %end


### PR DESCRIPTION
Added custom variable `_graph_num` to service description
Now you can choose which graph do you prefer to be displayed in problem page (instead of `graph[0]`).
If you omit `_graph_num`, default value 0 will be used

Example of use:
`check_cpu` which return bunch of stats (such as `user, irq, nice` etc).
default behaviour showed me random value (`softirq` in my case), but I wanted to get `user`
