### PR TITLE
Allow user to customize downtime duration using webui configuration file

### DIFF
--- a/etc/modules/webui2.cfg
+++ b/etc/modules/webui2.cfg
@@ -179,6 +179,9 @@ define module {
    # Default is 0
    #allow_anonymous            0
 
+   # Default Downtime scheduled from WebUI
+   # Default is 48
+   #default_downtime_hours     48
 
 
    ## Advanced Options for Bottle Web Server

--- a/module/module.py
+++ b/module/module.py
@@ -166,6 +166,9 @@ class Webui_broker(BaseModule, Daemon):
         self.manage_acl = to_bool(getattr(modconf, 'manage_acl', '1'))
         self.allow_anonymous = to_bool(getattr(modconf, 'allow_anonymous', '0'))
 
+        # Allow to customize default downtime duration
+        self.default_downtime_hours = int(getattr(modconf, 'default_downtime_hours', '48'))
+
         # Advanced options
         self.http_backend = getattr(modconf, 'http_backend', 'auto')
         self.remote_user_enable = getattr(modconf, 'remote_user_enable', '0')

--- a/module/plugins/forms/forms.py
+++ b/module/plugins/forms/forms.py
@@ -79,7 +79,7 @@ def form_comment_delete_all(name):
 def form_downtime_add(name):
     user = app.request.environ['USER']
     elt = app.datamgr.get_element(name, user) or app.redirect404()
-    return {'elt': elt, 'name': name}
+    return {'elt': elt, 'name': name, 'default_downtime_hours': app.default_downtime_hours}
 
 def form_downtime_delete(name):
     user = app.request.environ['USER']

--- a/module/plugins/forms/views/form_downtime_add.tpl
+++ b/module/plugins/forms/views/form_downtime_add.tpl
@@ -2,7 +2,7 @@
    // Initial start/stop for downtime, do not consider seconds ...
    var downtime_start = moment().seconds(0);
    // Set default downtime period as two days
-   var downtime_stop = moment().seconds(0).add('days', 2);
+   var downtime_stop = moment().seconds(0).add('hours', "{{ default_downtime_hours }}");
 
    function submit_local_form(){
       // Launch downtime request and bailout this modal view


### PR DESCRIPTION
Simple change to WebUI2 to allow customize downtime duration. For me, 2 days is waaay to long. I left it as default value, but it's now possible to change it with 

```
$ grep downtime /etc/shinken/modules/webui2.cfg 
	default_downtime_hours	2	; Set duration of default downtime
```
