### PR TITLE
Anonymous users get access to all pages when allow_anonymous is enabled

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -841,6 +841,9 @@ def login_required():
         else:
             contact = app.datamgr.get_contact(cookie_value)
     else:
+     # Only the /dashboard/currently should be accessible to anonymous users
+        if request.urlparts.path != "/dashboard/currently":
+            bottle.redirect("/user/login")
         contact = app.datamgr.get_contact('anonymous')
     if not contact:
         bottle.redirect("/user/login")


### PR DESCRIPTION
The documentation specify that `The allow_anonymous property allows to grant access to anonymous users on some application URI. Currently, the only 'opened' URI is the "one eye" dashboard view.` without this patch the anonymous user gets admin access to all screens using the documentation contact definition [doc](https://github.com/shinken-monitoring/mod-webui/wiki/Configuration---Main-parameters#user-management)