### PR TITLE
Update header_element.tpl

### DIFF
--- a/module/views/header_element.tpl
+++ b/module/views/header_element.tpl
@@ -193,7 +193,8 @@
         <li> <a href="#"><i class="fa fa-wrench"></i> Configuration <i class="fa arrow"></i></a>
           <ul class="nav nav-second-level">
             <li> <a href="{{ app.get_url('Parameters') }}"> <span class="fa fa-gears"></span> Parameters </a> </li>
-            <li> <a href="{{ app.get_url('ContactsGroups') }}"> <span class="fa fa-users"></span> Contacts </a> </li>
+            <li> <a href="{{ app.get_url('Contacts') }}"> <span class="fa fa-user"></span> Contacts </a> </li>
+            <li> <a href="{{ app.get_url('ContactsGroups') }}"> <span class="fa fa-users"></span> Contact Groups </a> </li>
             <li> <a href="{{ app.get_url('Commands') }}"> <span class="fa fa-terminal"></span> Commands </a> </li>
             <li> <a href="{{ app.get_url('TimePeriods') }}"> <span class="fa fa-calendar"></span> Time periods </a> </li>
           </ul>


### PR DESCRIPTION
Included 'Contacts' as well as 'Contacts Groups' to provide a link to each view of system contacts. WebUI 2.0.1 had 'Contacts' link to a listing of all contacts. WebUI 2.2.1 has a link of 'Contacts' which renders contact groups. This change lets the user navigate to either or without URI manipulation.