### PR TITLE
Fixed bug with toggle switches 

### DIFF
--- a/module/htdocs/js/shinken-actions.js
+++ b/module/htdocs/js/shinken-actions.js
@@ -209,51 +209,44 @@ function recheck_now(name) {
  * See #226
  */
 function toggle_active_checks(name, b){
+   var elts = get_elements(name);
+
    if (actions_logs) console.debug("Toggle active checks for: ", name, ", currently: ", b)
 
-   var elts = get_elements(name);
-   // Inverse the active check or not for the element
-   if (b) { // go disable
-      disable_checks(elts, false);
-   } else { // Go enable, passive too
-      enable_checks(elts, false);
+   if (b) {
+      var url = '/action/DISABLE_' + elts.type + '_CHECK/' + elts.nameslash;
+      launch(url, 'Active checks disabled');
+   } else {
+      var url = '/action/ENABLE_' + elts.type + '_CHECK/' + elts.nameslash;
+      launch(url, 'Active checks enabled');
    }
 }
 function toggle_passive_checks(name, b){
+   var elts = get_elements(name);
+
    if (actions_logs) console.debug("Toggle passive checks for: ", name, ", currently: ", b)
 
-   var elts = get_elements(name);
-   // Inverse the passive check or not for the element
    if (b) {
-      disable_checks(elts, true);
+      var url = '/action/DISABLE_PASSIVE_' + elts.type + '_CHECKS/' + elts.nameslash;
+      launch(url, 'Passive checks disabled');
    } else {
-      enable_checks(elts, true);
-   }
-}
-function enable_checks(elts, passive_too){
-   var url = '/action/ENABLE_'+elts.type+'_CHECK/'+elts.nameslash;
-   launch(url, 'Active checks enabled');
-   if (passive_too){
-      var url = '/action/ENABLE_PASSIVE_'+elts.type+'_CHECKS/'+elts.nameslash;
+      var url = '/action/ENABLE_PASSIVE_' + elts.type + '_CHECKS/' + elts.nameslash;
       launch(url, 'Passive checks enabled');
    }
-   // Enable host services only if it's an host ;)
-   if (elts.type == 'HOST'){
-      var url = '/action/ENABLE_HOST_SVC_CHECKS/'+elts.nameslash;
-      launch(url, 'Host services checks enabled');
-   }
 }
-function disable_checks(elts, passive_too){
-   var url = '/action/DISABLE_'+elts.type+'_CHECK/'+elts.nameslash;
-   launch(url, 'Active checks disabled');
-   if (passive_too){
-      var url = '/action/DISABLE_PASSIVE_'+elts.type+'_CHECKS/'+elts.nameslash;
-      launch(url, 'Passive checks disabled');
-   }
-   // Disable host services only if it's an host ;)
-   if (elts.type == 'HOST'){
-      var url = '/action/DISABLE_HOST_SVC_CHECKS/'+elts.nameslash;
-      launch(url, 'Host services checks disabled');
+function toggle_host_checks(name, b){
+   var elts = get_elements(name);
+
+   if (elts.type == 'HOST') {
+      if (actions_logs) console.debug("Toggle host checks for: ", name, ", currently: ", b);
+
+      if (b) {
+          var url = '/action/DISABLE_HOST_SVC_CHECKS/' + elts.nameslash;
+          launch(url, 'Host services checks disabled');
+      } else {
+          var url = '/action/ENABLE_HOST_SVC_CHECKS/' + elts.nameslash;
+          launch(url, 'Host services checks enabled');
+      }
    }
 }
 

--- a/module/plugins/eltdetail/htdocs/js/eltdetail.js
+++ b/module/plugins/eltdetail/htdocs/js/eltdetail.js
@@ -119,44 +119,60 @@ function on_page_refresh() {
    // Toggles ...
    $('input[action="toggle-active-checks"]').on('switchChange.bootstrapSwitch', function (e, data) {
       var elt = $(this).data('element');
-      var value = $(this).data('value')=='False' ? false : true;
-      if (eltdetail_logs) console.debug("Toggle active checks for: ", elt, ", currently: ", value)
+      var value = data==false ? true : false;
+      if (eltdetail_logs) console.debug("Toggle active checks for: ", elt, ", currently: ", value);
+
+      // Toggle active checks & host checks
       toggle_active_checks(elt, value);
+      toggle_host_checks(elt, value);
    });
    $('input[action="toggle-passive-checks"]').on('switchChange.bootstrapSwitch', function (e, data) {
       var elt = $(this).data('element');
-      var value = $(this).data('value')=='False' ? false : true;
-      if (eltdetail_logs) console.debug("Toggle passive checks for: ", elt, ", currently: ", value)
+      var value = data==false ? true : false;
+      if (eltdetail_logs) console.debug("Toggle passive checks for: ", elt, ", currently: ", value);
+
+      // Toggle passive checks
       toggle_passive_checks(elt, value);
+
+      // If active checks match the passive checks state, toggle active checks too
+      var active_check_value = $('input[action="toggle-active-checks"]').bootstrapSwitch('state');
+      if (value == active_check_value) {
+        $('input[action="toggle-active-checks"]').bootstrapSwitch('toggleState');
+      }
    });
    $('input[action="toggle-check-freshness"]').on('switchChange.bootstrapSwitch', function (e, data) {
       var elt = $(this).data('element');
-      var value = $(this).data('value')=='False' ? false : true;
-      if (eltdetail_logs) console.debug("Toggle freshness checks for: ", elt, ", currently: ", value)
+      var value = data==false ? true : false;
+      if (eltdetail_logs) console.debug("Toggle freshness checks for: ", elt, ", currently: ", value);
+
       toggle_freshness_check(elt, value);
    });
    $('input[action="toggle-notifications"]').on('switchChange.bootstrapSwitch', function (e, data) {
       var elt = $(this).data('element');
-      var value = $(this).data('value')=='False' ? false : true;
-      if (eltdetail_logs) console.debug("Toggle notifications for: ", elt, ", currently: ", value)
+      var value = data==false ? true : false;
+      if (eltdetail_logs) console.debug("Toggle notifications for: ", elt, ", currently: ", value);
+
       toggle_notifications(elt, value);
    });
    $('input[action="toggle-event-handler"]').on('switchChange.bootstrapSwitch', function (e, data) {
       var elt = $(this).data('element');
-      var value = $(this).data('value')=='False' ? false : true;
-      if (eltdetail_logs) console.debug("Toggle event handler for: ", elt, ", currently: ", value)
+      var value = data==false ? true : false;
+      if (eltdetail_logs) console.debug("Toggle event handler for: ", elt, ", currently: ", value);
+
       toggle_event_handlers(elt, value);
    });
    $('input[action="toggle-process-perfdata"]').on('switchChange.bootstrapSwitch', function (e, data) {
       var elt = $(this).data('element');
-      var value = $(this).data('value')=='False' ? false : true;
-      if (eltdetail_logs) console.debug("Toggle perfdata processing for: ", elt, ", currently: ", value)
+      var value = data==false ? true : false;
+      if (eltdetail_logs) console.debug("Toggle perfdata processing for: ", elt, ", currently: ", value);
+
       toggle_process_perfdata(elt, value);
    });
    $('input[action="toggle-flap-detection"]').on('switchChange.bootstrapSwitch', function (e, data) {
       var elt = $(this).data('element');
-      var value = $(this).data('value')=='False' ? false : true;
-      if (eltdetail_logs) console.debug("Toggle flap detection for: ", elt, ", currently: ", value)
+      var value = data==false ? true : false;
+      if (eltdetail_logs) console.debug("Toggle flap detection for: ", elt, ", currently: ", value);
+
       toggle_flap_detection(elt, value);
    });
 


### PR DESCRIPTION
Previously, toggle switches would just continue to do the same thing (example: Disable notifications) until the page refreshed. This fixes that. If you disable notifications & want to re-enable them before the page refreshes, you can. This update will also toggle the Active checks switch with the Passive checks switch if their states match. Feedback is welcome!