### PR TITLE
Match overall services states & correct interval length in element detail

### DIFF
--- a/module/datamanager.py
+++ b/module/datamanager.py
@@ -630,18 +630,24 @@ class WebUIDataManager(DataManager):
                 elif s.lower() == 'impact':
                     items = [i for i in items if i.is_impact]
                 else:
-                    # Manage SOFT state
+                    # Manage SOFT & HARD state
                     if s.startswith('s'):
                         s = s[1:]
                         if len(s) == 1:
                             items = [i for i in items if i.state_id == int(s) and i.state_type != 'HARD']
                         else:
                             items = [i for i in items if i.state == s.upper() and i.state_type != 'HARD']
+                    elif s.startswith('h'):
+                        s = s[1:]
+                        if len(s) == 1:
+                            items = [i for i in items if i.state_id != int(s) and i.state_type == 'HARD']
+                        else:
+                            items = [i for i in items if i.state != s.upper() and i.state_type == 'HARD']
                     else:
                         if len(s) == 1:
-                            items = [i for i in items if i.state_id == int(s) and i.state_type == 'HARD']
+                            items = [i for i in items if i.state_id == int(s)]
                         else:
-                            items = [i for i in items if i.state == s.upper() and i.state_type == 'HARD']
+                            items = [i for i in items if i.state == s.upper()]
 
             if t == 'isnot':
                 if s.lower() == 'ack':
@@ -653,18 +659,24 @@ class WebUIDataManager(DataManager):
                 elif s.lower() == 'impact':
                     items = [i for i in items if not i.is_impact]
                 else:
-                    # Manage soft state
+                    # Manage soft & hard state
                     if s.startswith('s'):
                         s = s[1:]
                         if len(s) == 1:
                             items = [i for i in items if i.state_id != int(s) and i.state_type != 'HARD']
                         else:
                             items = [i for i in items if i.state != s.upper() and i.state_type != 'HARD']
-                    else:
+                    elif s.startswith('h'):
+                        s = s[1:]
                         if len(s) == 1:
                             items = [i for i in items if i.state_id != int(s) and i.state_type == 'HARD']
                         else:
                             items = [i for i in items if i.state != s.upper() and i.state_type == 'HARD']
+                    else:
+                        if len(s) == 1:
+                            items = [i for i in items if i.state_id != int(s)]
+                        else:
+                            items = [i for i in items if i.state != s.upper()]
 
             # :COMMENT:maethor:150616: Legacy filters, kept for bookmarks compatibility
             if t == 'ack':

--- a/module/plugins/eltdetail/eltdetail.py
+++ b/module/plugins/eltdetail/eltdetail.py
@@ -42,7 +42,14 @@ def show_host(host_name):
     now = int(time.time())
     graphstart = int(app.request.GET.get('graphstart', str(now - 4 * 3600)))
     graphend = int(app.request.GET.get('graphend', str(now)))
-    return {'elt': h, 'graphstart': graphstart, 'graphend': graphend}
+
+    configs = app.datamgr.get_configs()
+    if configs:
+        configintervallength = vars(configs[0])['interval_length']
+    else:
+        configintervallength = 1
+
+    return {'elt': h, 'graphstart': graphstart, 'graphend': graphend, 'configintervallength': configintervallength}
 
 
 # Service element view
@@ -58,7 +65,13 @@ def show_service(host_name, service):
     graphstart = int(app.request.GET.get('graphstart', str(now - 4 * 3600)))
     graphend = int(app.request.GET.get('graphend', str(now)))
 
-    return {'elt': s, 'graphstart': graphstart, 'graphend': graphend}
+    configs = app.datamgr.get_configs()
+    if configs:
+        configintervallength = vars(configs[0])['interval_length']
+    else:
+        configintervallength = 1
+
+    return {'elt': s, 'graphstart': graphstart, 'graphend': graphend, 'configintervallength': configintervallength}
 
 
 pages = {

--- a/module/plugins/eltdetail/views/eltdetail.tpl
+++ b/module/plugins/eltdetail/views/eltdetail.tpl
@@ -518,11 +518,11 @@ Invalid element name
                               %if (elt.active_checks_enabled):
                               <tr>
                                  <td><strong>Check interval:</strong></td>
-                                 <td>{{elt.check_interval}} seconds</td>
+                                 <td>{{elt.check_interval*configintervallength}} seconds</td>
                               </tr>
                               <tr>
                                  <td><strong>Retry interval:</strong></td>
-                                 <td>{{elt.retry_interval}} seconds</td>
+                                 <td>{{elt.retry_interval*configintervallength}} seconds</td>
                               </tr>
                               <tr>
                                  <td><strong>Max check attempts:</strong></td>

--- a/module/views/modal_helpsearch.tpl
+++ b/module/views/modal_helpsearch.tpl
@@ -38,11 +38,14 @@
     <li><code>is:ack</code> Matches elements that are acknownledged.</li>
     <li><code>is:downtime</code> Matches elements that are in a scheduled downtime.</li>
   </ul>
-  <p><strong>Note:</strong> default search on state is made only against HARD states.</p>
-  <p>Preceding the state with the letter <code>s</code> makes the search only consider SOFT states. For example:</p>
+  <p><strong>Note:</strong> default search on state is made against HARD and SOFT states.</p>
+  <p>Preceding the state with the letter <code>s</code> makes the search only consider SOFT states.</p>
+  <p>You can also preceding the state with the letter <code>h</code> to made the search only cosider HARD states.</p>
+  <p>For example:</p>
   <ul>
     <li><code>is:sDOWN</code> Matches hosts that are SOFT state DOWN.</li>
-    <li><code>isnot:s0</code> Matches services and hosts that are SOFT state not OK neither UP (all the not yet confirmed problems)</li>
+    <li><code>isnot:0</code> Matches services and hosts that are SOFT state not OK neither UP (all the not yet confirmed problems)</li>
+    <li><code>is:hCRITICAL</code> Matches services that are HARD state CRITICAL.</li>
   </ul>
 
   <h4>Search by the business impact of an element</h4>

--- a/module/views/modal_helpsearch.tpl
+++ b/module/views/modal_helpsearch.tpl
@@ -44,7 +44,7 @@
   <p>For example:</p>
   <ul>
     <li><code>is:sDOWN</code> Matches hosts that are SOFT state DOWN.</li>
-    <li><code>isnot:0</code> Matches services and hosts that are SOFT state not OK neither UP (all the not yet confirmed problems)</li>
+    <li><code>isnot:s0</code> Matches services and hosts that are SOFT state not OK neither UP (all the not yet confirmed problems)</li>
     <li><code>is:hCRITICAL</code> Matches services that are HARD state CRITICAL.</li>
   </ul>
 


### PR DESCRIPTION
Hello,

When you see a problem in the overall service state and that problem is in SOFT state it's not shown when you want to see it.
![image](https://cloud.githubusercontent.com/assets/5681800/15531656/cb0841bc-225b-11e6-963f-9dabe89c242c.png)
![image](https://cloud.githubusercontent.com/assets/5681800/15531692/f9dadd38-225b-11e6-937c-5248fb0b8faf.png)

This patch allow to see problems in all state and add a filter to show only hard state.
