### PR TITLE
Improve popovers throughout the UI

### DIFF
--- a/module/htdocs/css/shinken-layout.css
+++ b/module/htdocs/css/shinken-layout.css
@@ -175,6 +175,17 @@ html, body {
 }
 
 /*
+ * Navigation bar, state displays
+ */
+.navbar-top-links li .popover a {
+    padding: 0px;
+}
+
+.navbar-top-links li .popover a:hover {
+    text-decoration: none;
+}
+
+/*
  * Navigation bar, user menu
  */
 .user-menu > .dropdown-menu {

--- a/module/plugins/eltdetail/htdocs/js/eltdetail.js
+++ b/module/plugins/eltdetail/htdocs/js/eltdetail.js
@@ -45,12 +45,23 @@ function on_page_refresh() {
 //   $('[data-toggle="popover"]').popover();
 
    $('[data-toggle="popover"]').popover({
-      trigger: "hover",
-      container: "body",
-      placement: 'bottom',
-      toggle : "popover",
+      trigger: 'manual',
+      animation: false,
 
       template: '<div class="popover popover-large"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>'
+   }).on("mouseenter", function () {
+      var _this = this;
+      $(this).popover("show");
+      $(this).siblings(".popover").on("mouseleave", function () {
+          $(_this).popover('hide');
+      });
+   }).on("mouseleave", function () {
+      var _this = this;
+      setTimeout(function () {
+          if (!$(_this).siblings(".popover").is(":hover")) {
+              $(_this).popover("hide");
+          }
+      }, 100);
    });
 
    /*

--- a/module/plugins/eltdetail/views/eltdetail.tpl
+++ b/module/plugins/eltdetail/views/eltdetail.tpl
@@ -386,12 +386,13 @@ Invalid element name
                               </tr>
                               <tr>
                                  <td><strong>Since:</strong></td>
-                                 <td class="popover-dismiss"
-                                       data-html="true" data-toggle="popover" data-trigger="hover" data-placement="bottom"
+                                 <td><span class="popover-dismiss"
+                                       data-html="true" data-toggle="popover" data-placement="bottom"
                                        data-title="{{elt.get_full_name()}} last state change date"
                                        data-content=" {{time.strftime('%d %b %Y %H:%M:%S', time.localtime(elt.last_state_change))}} "
                                        >
                                     {{! helper.print_duration(elt.last_state_change, just_duration=True, x_elts=2)}}
+                                    </span>
                                  </td>
                               </tr>
                            </tbody>
@@ -410,26 +411,28 @@ Invalid element name
                            <tbody style="font-size:x-small;">
                               <tr>
                                  <td><strong>Last Check:</strong></td>
-                                 <td><span class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Last check was at {{time.asctime(time.localtime(elt.last_chk))}}">was {{helper.print_duration(elt.last_chk)}}</span></td>
+                                 <td><span class="popover-dismiss" data-html="true" data-toggle="popover" data-placement="bottom" data-content="Last check was at {{time.asctime(time.localtime(elt.last_chk))}}">was {{helper.print_duration(elt.last_chk)}}</span></td>
                               </tr>
                               <tr>
                                  <td><strong>Output:</strong></td>
-                                 <td class="popover-dismiss popover-large"
-                                       data-html="true" data-toggle="popover" data-trigger="hover" data-placement="bottom"
+                                 <td><span class="popover-dismiss popover-large"
+                                       data-html="true" data-toggle="popover" data-placement="bottom"
                                        data-title="{{elt.get_full_name()}} check output"
                                        data-content=" {{elt.output}}{{'<br/>'+elt.long_output.replace('\n', '<br/>') if elt.long_output else ''}}"
                                        >
                                   {{!helper.strip_html_output(elt.output) if app.allow_html_output else elt.output}}
+                                    </span>
                                  </td>
                               </tr>
                               <tr>
                                  <td><strong>Performance data:</strong></td>
-                                 <td class="popover-dismiss popover-large ellipsis"
-                                       data-html="true" data-toggle="popover" data-trigger="hover" data-placement="bottom"
+                                 <td><span class="popover-dismiss popover-large ellipsis"
+                                       data-html="true" data-toggle="popover" data-placement="bottom"
                                        data-title="{{elt.get_full_name()}} performance data"
                                        data-content=" {{elt.perf_data if elt.perf_data else '(none)'}}"
                                        >
                                   {{elt.perf_data if elt.perf_data else '(none)'}}
+                                    </span>
                                  </td>
                               </tr>
                               <tr>
@@ -441,7 +444,7 @@ Invalid element name
 
                               <tr>
                                  <td><strong>Last State Change:</strong></td>
-                                 <td><span class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Last state change at {{time.asctime(time.localtime(elt.last_state_change))}}">{{helper.print_duration(elt.last_state_change)}}</span></td>
+                                 <td><span class="popover-dismiss" data-html="true" data-toggle="popover" data-placement="bottom" data-content="Last state change at {{time.asctime(time.localtime(elt.last_state_change))}}">{{helper.print_duration(elt.last_state_change)}}</span></td>
                               </tr>
                               <tr>
                                  <td><strong>Current Attempt:</strong></td>
@@ -449,7 +452,7 @@ Invalid element name
                               </tr>
                               <tr>
                                  <td><strong>Next Active Check:</strong></td>
-                                 <td><span class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-content="Next active check at {{time.asctime(time.localtime(elt.next_chk))}}">{{helper.print_duration(elt.next_chk)}}</span></td>
+                                 <td><span class="popover-dismiss" data-html="true" data-toggle="popover" data-placement="bottom" data-content="Next active check at {{time.asctime(time.localtime(elt.next_chk))}}">{{helper.print_duration(elt.next_chk)}}</span></td>
                               </tr>
                            </tbody>
                         </table>
@@ -470,7 +473,7 @@ Invalid element name
                                  <td><strong>Check period:</strong></td>
                                  %tp=app.datamgr.get_timeperiod(elt.check_period.get_name())
                                  <td name="check_period" class="popover-dismiss"
-                                       data-html="true" data-toggle="popover" data-trigger="hover" data-placement="left"
+                                       data-html="true" data-toggle="popover" data-placement="left"
                                        data-title='{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}'
                                        data-content='{{!helper.get_timeperiod_html(tp)}}'
                                        >
@@ -488,7 +491,7 @@ Invalid element name
                               <tr>
                                  <td><strong>Maintenance period:</strong></td>
                                  <td name="maintenance_period" class="popover-dismiss"
-                                       data-html="true" data-toggle="popover" data-trigger="hover" data-placement="left"
+                                       data-html="true" data-toggle="popover" data-placement="left"
                                        data-title='{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}'
                                        data-content='{{!helper.get_timeperiod_html(tp)}}'
                                        >
@@ -699,7 +702,7 @@ Invalid element name
                               <tr>
                                  <td><strong>Notification period:</strong></td>
                                  %tp=app.datamgr.get_timeperiod(elt.notification_period.get_name())
-                                 <td name="notification_period" class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" data-placement="left"
+                                 <td name="notification_period" class="popover-dismiss" data-html="true" data-toggle="popover" data-placement="left"
                                        data-title='{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}'
                                        data-content='{{!helper.get_timeperiod_html(tp)}}'>
                                     {{! helper.get_on_off(elt.notification_period.is_time_valid(now), 'Is element notification period currently active?')}}
@@ -1140,7 +1143,7 @@ Invalid element name
                                           data-toggle="popover" title="{{ elt.get_full_name() }}"
                                           data-html="true"
                                           data-content="<img src='{{ graph['img_src'] }}' width='600px' height='200px'>"
-                                          data-trigger="hover" data-placement="left">{{!helper.get_perfometer(elt, metric.name)}}</a>
+                                          data-placement="left">{{!helper.get_perfometer(elt, metric.name)}}</a>
                                     %end
                                  %end
                               </td>
@@ -1182,7 +1185,7 @@ Invalid element name
                                           data-toggle="popover" title="{{ s.get_full_name() }}"
                                           data-html="true"
                                           data-content="<img src='{{ graph['img_src'] }}' width='600px' height='200px'>"
-                                          data-trigger="hover" data-placement="left">{{!helper.get_perfometer(s, metric.name)}}</a>
+                                          data-placement="left">{{!helper.get_perfometer(s, metric.name)}}</a>
                                     %end
                                  %end
                               </td>

--- a/module/views/header_element.tpl
+++ b/module/views/header_element.tpl
@@ -36,7 +36,13 @@
                %for state in "up", "unreachable", "down", "pending", "unknown", "ack", "downtime":
                <td>
                  %label = "%s <i>(%s%%)</i>" % (h["nb_" + state], h["pct_" + state])
+                 %if state in ['ack', 'downtime']:
+                 <a href="/all?search=type:host is:{{state}}">
+                 %else:
+                 <a href="/all?search=type:host is:{{state}} isnot:ack isnot:downtime">
+                 %end
                  {{!helper.get_fa_icon_state_and_label(cls="host", state=state, label=label, disabled=(not h["nb_" + state]))}}
+                 </a>
                </td>
                %end
             </tr>
@@ -50,7 +56,13 @@
                %for state in "ok", "warning", "critical", "pending", "unknown", "ack", "downtime":
                <td>
                  %label = "%s <i>(%s%%)</i>" % (s["nb_" + state], s["pct_" + state])
+                 %if state in ['ack', 'downtime']:
+                 <a href="/all?search=type:service is:{{state}}">
+                 %else:
+                 <a href="/all?search=type:service is:{{state}} isnot:ack isnot:downtime">
+                 %end
                  {{!helper.get_fa_icon_state_and_label(cls="service", state=state, label=label, disabled=(not s["nb_" + state]))}}
+                 </a>
                </td>
                %end
             </tr>
@@ -70,7 +82,7 @@
          <a id="hosts-states-popover"
             class="hosts-all" data-count="{{ h['nb_elts'] }}" data-problems="{{ h['nb_problems'] }}"
             href="/all?search=type:host"
-            data-original-title="Hosts states" data-toggle="popover popover-hosts" title="Overall hosts states: {{h['nb_elts']}} hosts, {{h["nb_problems"]}} problems" data-html="true" data-trigger="hover">
+            data-original-title="Hosts states" data-toggle="popover popover-hosts" title="Overall hosts states: {{h['nb_elts']}} hosts, {{h["nb_problems"]}} problems">
             <i class="fa fa-server"></i>
             <span class="label label-as-badge label-{{label}}">{{h["nb_problems"]}}</span>
          </a>
@@ -88,7 +100,7 @@
          <a id="services-states-popover"
             class="services-all" data-count="{{ s['nb_elts'] }}" data-problems="{{ s['nb_problems'] }}"
             href="/all?search=type:service"
-            data-original-title="Services states" data-toggle="popover popover-services" title="Overall services states: {{s['nb_elts']}} services, {{s["nb_problems"]}} problems" data-html="true" data-trigger="hover">
+            data-original-title="Services states" data-toggle="popover popover-services" title="Overall services states: {{s['nb_elts']}} services, {{s["nb_problems"]}} problems">
             <i class="fa fa-bars"></i>
             <span class="label label-as-badge label-{{label}}">{{s["nb_problems"]}}</span>
          </a>
@@ -269,20 +281,48 @@
    // Activate the popover ...
    $('#hosts-states-popover').popover({
       placement: 'bottom',
-      animation: true,
+      trigger: 'manual',
+      animation: false,
       template: '<div class="popover img-popover"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>',
       content: function() {
          return $('#hosts-states-popover-content').html();
       }
+   }).on("mouseenter", function () {
+      var _this = this;
+      $(this).popover("show");
+      $(this).siblings(".popover").on("mouseleave", function () {
+          $(_this).popover('hide');
+      });
+   }).on("mouseleave", function () {
+      var _this = this;
+      setTimeout(function () {
+          if (!$(".popover:hover").length) {
+              $(_this).popover("hide");
+          }
+      }, 100);
    });
 
    // Activate the popover ...
    $('#services-states-popover').popover({
       placement: 'bottom',
-      animation: true,
+      trigger: 'manual',
+      animation: false,
       template: '<div class="popover img-popover"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>',
       content: function() {
          return $('#services-states-popover-content').html();
       }
+   }).on("mouseenter", function () {
+      var _this = this;
+      $(this).popover("show");
+      $(this).siblings(".popover").on("mouseleave", function () {
+          $(_this).popover('hide');
+      });
+   }).on("mouseleave", function () {
+      var _this = this;
+      setTimeout(function () {
+          if (!$(".popover:hover").length) {
+              $(_this).popover("hide");
+          }
+      }, 100);
    });
 </script>


### PR DESCRIPTION
The use of popovers in the UI was causing some headaches, so here are some changes to give them a slight more usability.

- Popovers now stay open when hovering over their content.
  - With this, Host and Service status popovers now house links to all the sections shown inside them.
- You can now select the content inside Host and Service information popovers without them closing.
- Information popovers in Host and Service information pages now center on the content instead of on the table cell.