### PR TITLE
eltdetail: Fix undefined variable `tp`

### DIFF
--- a/module/plugins/eltdetail/views/_eltdetail_information.tpl
+++ b/module/plugins/eltdetail/views/_eltdetail_information.tpl
@@ -131,6 +131,7 @@
             %if elt.maintenance_period is not None:
             <tr>
               <td><strong>Maintenance period:</strong></td>
+              %tp=app.datamgr.get_timeperiod(elt.maintenance_period.get_name())
               <td name="maintenance_period" class="popover-dismiss"
                 data-html="true" data-toggle="popover" data-placement="left"
                 data-title='{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}'


### PR DESCRIPTION
This would cause a 500 error when visiting the host page for a host with
a maintenance period set.

Apparently not many people have been using maintenance periods for their hosts in Shinken.