### PR TITLE
Filter service by the exact name

### DIFF
--- a/module/datamanager.py
+++ b/module/datamanager.py
@@ -226,7 +226,7 @@ class WebUIDataManager(DataManager):
 
             return None
 
-        services = self.search_hosts_and_services('type:service host:^%s$ service:"%s"' % (hname, sname), user=user)
+        services = self.search_hosts_and_services('type:service host:^%s$ service:"^%s$"' % (hname, sname), user=user)
         return services[0] if services else None
 
     def get_percentage_service_state(self, user=None, problem=False):


### PR DESCRIPTION
Fixes service selection when one service name includes the other.

For example, the following page https://shinken.local/service/thehost/Disks would show service Disks or DiskIO.