### PR TITLE
Better handling of bookmarks

### DIFF
--- a/module/htdocs/js/shinken-bookmarks.js
+++ b/module/htdocs/js/shinken-bookmarks.js
@@ -40,6 +40,11 @@ function save_bookmarksro(){
    });
 }
 
+// String handling
+function safe_string(string) {
+   return String(string).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 // Create bookmaks lists ...
 function declare_bookmark(name, uri){
    var exists=false;
@@ -132,12 +137,12 @@ function delete_bookmarkro(name){
 
 var search_string='';
 $(document).ready(function(){
-   search_string = $('#search').val();
+   search_string = safe_string($('#search').val());
    refresh_bookmarks(search_string);
    
    // Display modal to add a new bookmark ...
    $('body').on("click", '[action="display-add-bookmark"]', function (e, data) {
-      search_string = $(this).data('filter');
+      search_string = safe_string($(this).data('filter'));
       display_modal('/modal/newbookmark');
    });
 
@@ -145,7 +150,7 @@ $(document).ready(function(){
    $('body').on("click", '[action="add-bookmark"]', function (e, data) {
       var bkm_type = $(this).data('bookmark_type');
       
-      var name = $('#new_bookmark_name').val();
+      var name = safe_string($('#new_bookmark_name').val());
       if (name=='') return;
 
       // Do not save the bm if there is already one with this name

--- a/module/views/modal_managebookmarks.tpl
+++ b/module/views/modal_managebookmarks.tpl
@@ -3,13 +3,13 @@
 
 %for b in user_bookmarks:
 <script type="text/javascript">
-   declare_bookmark("{{!b['name']}}","{{!b['uri']}}");
+   declare_bookmark("{{b['name']}}","{{b['uri']}}");
 </script>
 %end
 
 %for b in common_bookmarks:
 <script type="text/javascript">
-   declare_bookmarksro("{{!b['name']}}","{{!b['uri']}}");
+   declare_bookmarksro("{{b['name']}}","{{b['uri']}}");
 </script>
 %end
 
@@ -24,10 +24,10 @@
    <ul class="list-group">
       %for b in user_bookmarks:
       <li class="list-group-item" role="presentation">
-         <a role="menuitem" tabindex="-1" href="{{!b['uri']}}"><i class="fa fa-bookmark"></i> {{!b['name']}}</a>
-         <button action="delete-bookmark" data-bookmark="{{!b['name']}}" data-bookmark_type="user" class="btn btn-xs btn-danger pull-right"><i class="fa fa-minus"></i> Delete</button>
+         <a role="menuitem" tabindex="-1" href="/all?search={{b['uri']}}"><i class="fa fa-bookmark"></i> {{b['name']}}</a>
+         <button action="delete-bookmark" data-bookmark="{{b['name']}}" data-bookmark_type="user" class="btn btn-xs btn-danger pull-right"><i class="fa fa-minus"></i> Delete</button>
          <span class="pull-right">&nbsp;</span>
-         <button action="globalize-bookmark" data-bookmark="{{!b['name']}}" data-bookmark_type="user" class="btn btn-xs btn-info pull-right"><i class="fa fa-plus"> Make it global</i></button>
+         <button action="globalize-bookmark" data-bookmark="{{b['name']}}" data-bookmark_type="user" class="btn btn-xs btn-info pull-right"><i class="fa fa-plus"> Make it global</i></button>
       </li>
       %end
    </ul>
@@ -38,8 +38,8 @@
    <ul class="list-group">
       %for b in common_bookmarks:
       <li class="list-group-item" role="presentation">
-         <a role="menuitem" tabindex="-1" href="{{!b['uri']}}"><i class="fa fa-bookmark"></i> {{!b['name']}}</a>
-         <button action="delete-bookmark" data-bookmark="{{!b['name']}}" data-bookmark_type="global" class="btn btn-xs btn-danger pull-right"><i class="fa fa-minus"></i> Delete</button>
+         <a role="menuitem" tabindex="-1" href="/all?search={{b['uri']}}"><i class="fa fa-bookmark"></i> {{b['name']}}</a>
+         <button action="delete-bookmark" data-bookmark="{{b['name']}}" data-bookmark_type="global" class="btn btn-xs btn-danger pull-right"><i class="fa fa-minus"></i> Delete</button>
       </li>
       %end
    </ul>


### PR DESCRIPTION
We ran into #542 at work today, so I sat down to figure out why the issue exists and how to solve it.  
Here's a mostly client-side solution for the issue. (Instead of handling quotes and escaping them correctly on the python side I just pass them as `&quot;` entities down from the web ui)

The problem stems from the HTML concatenation in [`refresh_bookmarks`](https://github.com/shinken-monitoring/mod-webui/blob/develop/module/htdocs/js/shinken-bookmarks.js#L77-L106), where any bookmarks containing quotes will end up breaking the generated HTML, before bubbling upwards to affect saving and browsing to the saved bookmarks as well.

The same issue also happens in [modal_managebookmarks.tpl](https://github.com/shinken-monitoring/mod-webui/blob/develop/module/views/modal_managebookmarks.tpl) where HTML is generated containing quotes instead of `&quot;` entities.  
I'll see about maybe adding in some validation on the server side as well tomorrow, replacing HTML entities when loading and saving to the database.

An additional fix that's included here changes the generated links in the bookmarks modal to actually link to the search page instead of just being a link of the bookmark search text.