### PR TITLE
fix sound toggle bug

### DIFF
--- a/module/htdocs/js/shinken-layout.js
+++ b/module/htdocs/js/shinken-layout.js
@@ -147,7 +147,7 @@ $(document).ready(function(){
 
 
   // Sound
-  if ($("#alert-audio").length) {
+  if ($(".js-toggle-sound-alert").length) {
     // Set alerting sound icon ...
     if (! sessionStorage.getItem("sound_play")) {
       // Default is to play ...


### PR DESCRIPTION
# version

Shinken 2.4.3 — Web User Interface 2.6.1,
# page

all (bug in layout)

# expected behavior
when i click on the toggle sound icon, it should enable the sound, and change the icon of the button to remove the .fa-ban

# current behavior

clicking on the button do absolutly nothing. 

# fix

I found in shinken-layout.js that the block that manage the event on this button is surounded by a If which check if a outdated ID exists. i fix it by changing this query by id `#alert-audio` with a query  by class `.js-toggle-sound-alert` which target the same item, and is uniq.