### PR TITLE
fix sound icon missplacement due to span.fa-stack

### DIFF
--- a/module/htdocs/css/shinken-layout.css
+++ b/module/htdocs/css/shinken-layout.css
@@ -278,6 +278,10 @@ td .ellipsis > .long-output {
     padding: 5px 8px;
     line-height: 1.33;
 }
+/** remove padding for button with .fa-stack as child */
+.navbar-nav > li > .btn-ico.js-toggle-sound-alert {
+    padding: 0;
+}
 
 .navbar-nav > li > .btn-user {
     border-radius: 17px;


### PR DESCRIPTION
it seem this is the only button with this css issue. I reset the padding
to prevent the icon to be missplaced.

## before
![screenshot-shinken hominis int-2017-10-16-12-09-10](https://user-images.githubusercontent.com/5380232/31607057-308ae4d6-b26b-11e7-93e4-45b1168ce5bc.png)
## after css fix
![screenshot-shinken hominis int-2017-10-16-12-11-34](https://user-images.githubusercontent.com/5380232/31607093-5bd15436-b26b-11e7-9bd6-3e255ac0b7cf.png)
