### PR TITLE
fix tooltip breaking tables columns.

### DIFF
--- a/module/plugins/minemap/views/minemap.tpl
+++ b/module/plugins/minemap/views/minemap.tpl
@@ -114,7 +114,7 @@
                %h = app.datamgr.get_host(r, user)
                %if h:
                <tr>
-                  <td title="{{h.get_name()}} - {{h.state}} - {{helper.print_duration(h.last_chk)}} - {{h.output}}">
+                  <td title="{{h.get_name()}} - {{h.state}} - {{helper.print_duration(h.last_chk)}} - {{h.output}}" data-container="body">
                      <a href="/host/{{h.get_name()}}">
                         {{!helper.get_fa_icon_state(h, useTitle=False)}}
                         {{h.get_name() if h.display_name == '' else h.display_name}}
@@ -123,7 +123,7 @@
                   %for c in columns:
                      %s = app.datamgr.get_service(r, c, user)
                      %if s:
-                        <td title="{{s.get_name()}} - {{s.state}} - {{helper.print_duration(s.last_chk)}} - {{s.output}}">
+                        <td title="{{s.get_name()}} - {{s.state}} - {{helper.print_duration(s.last_chk)}} - {{s.output}}" data-container="body">
                            <a href="/service/{{h.get_name()}}/{{s.get_name()}}">
                               {{!helper.get_fa_icon_state(s, useTitle=False)}}
                            </a>

--- a/module/plugins/system/views/system.tpl
+++ b/module/plugins/system/views/system.tpl
@@ -50,7 +50,7 @@
                 <!--<td>{{!helper.get_on_off(status=s.spare)}}</td>-->
                 %end
                 <td>{{s.attempt}}/{{s.max_check_attempts}}</td>
-                <td title='{{helper.print_date(s.last_check)}}'>{{helper.print_duration(s.last_check, just_duration=True, x_elts=2)}}</td>
+                <td title='{{helper.print_date(s.last_check)}}' data-container="body">{{helper.print_duration(s.last_check, just_duration=True, x_elts=2)}}</td>
                 <td>{{s.realm}}</td>
              </tr>
              %end

--- a/module/plugins/system/views/system_widget.tpl
+++ b/module/plugins/system/views/system_widget.tpl
@@ -44,7 +44,7 @@
                     %end
                 %end
              </td>
-             <td title='{{helper.print_date(s.last_check)}}'>{{helper.print_duration(s.last_check, just_duration=True, x_elts=2)}}</td>
+             <td title='{{helper.print_date(s.last_check)}}' data-container="body">{{helper.print_duration(s.last_check, just_duration=True, x_elts=2)}}</td>
              <td>{{s.realm}}</td>
           </tr>
           %# End of this satellite


### PR DESCRIPTION
fix #590 

I just added the ` data-container="body"` to td with title. this may not cover all broken tables, but it did not saw others with this error. it seem that the ` data-container="body"` was already applied to some tables.