### PR TITLE
Fix slack alerts history

### DIFF
--- a/module/plugins/logs/logs.py
+++ b/module/plugins/logs/logs.py
@@ -26,6 +26,8 @@
 
 import time
 import datetime
+
+import json
 import urllib
 
 from shinken.log import logger
@@ -163,6 +165,10 @@ def get_history():
 
     command_name = app.request.GET.get('commandname', None)
     if command_name is not None:
+        try:
+            command_name = json.loads(command_name)
+        except:
+            pass
         filters['command_name'] = command_name
 
     limit = int(app.request.GET.get('limit', 100))

--- a/module/plugins/problems/problems.py
+++ b/module/plugins/problems/problems.py
@@ -33,7 +33,7 @@ import re
 
 
 def get_page():
-    app.bottle.redirect("/all?search=isnot:UP isnot:OK isnot:PENDING isnot:ACK isnot:DOWNTIME isnot:SOFT bp:>0")
+    app.bottle.redirect("/all?search=isnot:UP isnot:OK isnot:PENDING isnot:ACK isnot:DOWNTIME bp:>0")
 
 
 def get_all():

--- a/module/plugins/stats/stats.py
+++ b/module/plugins/stats/stats.py
@@ -38,7 +38,7 @@ def get_global_stats():
     range_end = int(app.request.GET.get('range_end', time.time()))
     range_start = int(app.request.GET.get('range_start', range_end - (days * 86400)))
 
-    logs = list(app.logs_module.get_ui_logs(range_start=range_start, range_end=range_end, filters={'type': 'SERVICE NOTIFICATION', 'command_name': 'notify-service-by-hubot'}, limit=None))
+    logs = list(app.logs_module.get_ui_logs(range_start=range_start, range_end=range_end, filters={'type': 'SERVICE NOTIFICATION', 'command_name': {'$regex':'notify-service-by-slack'}}, limit=None))
     hosts = Counter()
     services = Counter()
     hostsservices = Counter()
@@ -57,7 +57,7 @@ def get_service_stats(name):
     range_end = int(app.request.GET.get('range_end', time.time()))
     range_start = int(app.request.GET.get('range_start', range_end - (days * 86400)))
 
-    logs = list(app.logs_module.get_ui_logs(range_start=range_start, range_end=range_end, filters={'type': 'SERVICE NOTIFICATION', 'command_name': 'notify-service-by-hubot', 'service_description': name}, limit=None))
+    logs = list(app.logs_module.get_ui_logs(range_start=range_start, range_end=range_end, filters={'type': 'SERVICE NOTIFICATION', 'command_name': {'$regex':'notify-service-by-slack'}, 'service_description': name}, limit=None))
     hosts = Counter()
     for l in logs:
         hosts[l['host_name']] += 1
@@ -72,7 +72,7 @@ def get_host_stats(name):
     range_end = int(app.request.GET.get('range_end', time.time()))
     range_start = int(app.request.GET.get('range_start', range_end - (days * 86400)))
 
-    logs = list(app.logs_module.get_ui_logs(range_start=range_start, range_end=range_end, filters={'type': 'SERVICE NOTIFICATION', 'command_name': 'notify-service-by-hubot', 'host_name': name}, limit=None))
+    logs = list(app.logs_module.get_ui_logs(range_start=range_start, range_end=range_end, filters={'type': 'SERVICE NOTIFICATION', 'command_name': {'$regex':'notify-service-by-slack'}, 'host_name': name}, limit=None))
     services = Counter()
     for l in logs:
         services[l['service_description']] += 1

--- a/module/plugins/stats/views/stats.tpl
+++ b/module/plugins/stats/views/stats.tpl
@@ -44,7 +44,7 @@
 <div class="col-xs-12">
   <div class="panel panel-default">
     <div class="panel-body">
-      <div id="inner_history" data-logclass="3" data-commandname="notify-service-by-slack">
+      <div id="inner_history" data-logclass="3" data-commandname="{%22$regex%22:%22notify-service-by-slack%22}">
       </div>
 
       <div class="text-center" id="loading-spinner">

--- a/module/plugins/stats/views/stats_host.tpl
+++ b/module/plugins/stats/views/stats_host.tpl
@@ -18,7 +18,7 @@
 <div class="col-xs-12">
   <div class="panel panel-default">
     <div class="panel-body">
-      <div id="inner_history" data-host='{{ host }}' data-logclass="3" data-commandname="notify-service-by-slack">
+      <div id="inner_history" data-host='{{ host }}' data-logclass="3" data-commandname="{%22$regex%22:%22notify-service-by-slack%22}">
       </div>
 
       <div class="text-center" id="loading-spinner">

--- a/module/plugins/stats/views/stats_service.tpl
+++ b/module/plugins/stats/views/stats_service.tpl
@@ -18,7 +18,7 @@
 <div class="col-xs-12">
   <div class="panel panel-default">
     <div class="panel-body">
-      <div id="inner_history" data-service='{{ service }}' data-logclass="3" data-commandname="notify-service-by-slack">
+      <div id="inner_history" data-service='{{ service }}' data-logclass="3" data-commandname="{%22$regex%22:%22notify-service-by-slack%22}">
       </div>
 
       <div class="text-center" id="loading-spinner">


### PR DESCRIPTION
A fix on the stats module, so it works based on shinken notifications via slack (any notification command that matches `/notify-service-by-slack/` will be taken into account.
