### PR TITLE
Closes 629 - declare empty Mongo URI

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -248,6 +248,12 @@ class Webui_broker(BaseModule, Daemon):
         self.default_ack_notify = int(getattr(modconf, 'default_ack_notify', '1'))
         self.default_ack_persistent = int(getattr(modconf, 'default_ack_persistent', '1'))
 
+        # MongoDB connection
+        self.uri = getattr(modconf, "uri", "mongodb://localhost")
+        if not self.uri:
+            logger.warning("You defined an empty MongoDB connection URI. Features like user's preferences, or system"
+                           "log and hosts availability will not be available.")
+
         # Advanced options
         self.http_backend = getattr(modconf, 'http_backend', 'auto')
         self.remote_user_enable = getattr(modconf, 'remote_user_enable', '0')

--- a/module/plugins/eltdetail/views/eltdetail.tpl
+++ b/module/plugins/eltdetail/views/eltdetail.tpl
@@ -24,6 +24,9 @@ Invalid element name
 %end
 
 %js=['js/shinken-actions.js', 'js/jquery.sparkline.min.js', 'js/shinken-charts.js', 'availability/js/justgage.js', 'availability/js/raphael-2.1.4.min.js', 'cv_host/js/flot/jquery.flot.min.js', 'cv_host/js/flot/jquery.flot.tickrotor.js', 'cv_host/js/flot/jquery.flot.resize.min.js', 'cv_host/js/flot/jquery.flot.pie.min.js', 'cv_host/js/flot/jquery.flot.categories.min.js', 'cv_host/js/flot/jquery.flot.time.min.js', 'cv_host/js/flot/jquery.flot.stack.min.js', 'cv_host/js/flot/jquery.flot.valuelabels.js', 'eltdetail/js/custom_views.js', 'eltdetail/js/eltdetail.js', 'logs/js/history.js']
+%if app.logs_module.is_available():
+%js=js + ['availability/js/justgage.js', 'availability/js/raphael-2.1.4.min.js']
+%end
 %css=['eltdetail/css/eltdetail.css', 'cv_host/css/cv_host.css']
 
 %rebase("layout", js=js, css=css, breadcrumb=breadcrumb, title=elt_type.title()+' detail: ' + elt.get_full_name())


### PR DESCRIPTION
If an empty MongoDB URI is declare in the `uri` configuration parameter, it means that the administrato do not want to use any DB for the logs and availability information. As such, the corresponding menus are hidden in the UI