### PR TITLE
Clean groups and contacts views

### DIFF
--- a/module/plugins/contacts/views/contact.tpl
+++ b/module/plugins/contacts/views/contact.tpl
@@ -200,14 +200,16 @@
                      %if nw.host_notifications_enabled:
                      <tr>
                         <td><strong>&nbsp;&ndash;&nbsp;period:</strong></td>
-                        <td name="{{"host_notification_period%s" % i}}" class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" title="Host notification period" data-placement="top" data-content="...">{{! app.helper.get_on_off(nw.host_notification_period.is_time_valid(time.time()), "Is notification period currently active?")}}
+                        %tp=app.datamgr.get_timeperiod(nw.host_notification_period.get_name())
+                        <td name="{{"host_notification_period%s" % i}}" class="popover-dismiss" data-html="true"
+                            data-toggle="popover" data-trigger="hover" title="{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}"
+                            data-placement="bottom" data-content="{{! app.helper.get_timeperiod_html(tp)}}">
+                            {{! app.helper.get_on_off(nw.host_notification_period.is_time_valid(time.time()), "Is notification period currently active?")}}
                            <a href="/timeperiods">{{nw.host_notification_period.alias}}</a>
                            <script>
-                              %tp=app.datamgr.get_timeperiod(nw.host_notification_period.get_name())
-                              $('td[name="{{"host_notification_period%s" % i}}"]')
-                                .attr('title', '{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}')
-                                .attr('data-content', '{{! app.helper.get_timeperiod_html(tp)}}')
-                                .popover();
+                            $(document).ready(function(){
+                              $('td[name="{{"host_notification_period%s" % i}}"]').popover();
+                            });
                            </script>
                         </td>
                      </tr>
@@ -237,13 +239,13 @@
                        %i += 1
                        <tr>
                            <td><strong>&nbsp;&ndash;&nbsp;command:</strong></td>
-                           <td name="host_command{{i}}" class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" title="Host notification command" data-placement="top" data-content="...">
+                           <td name="host_command{{i}}" class="popover-dismiss" data-html="true" data-toggle="popover"
+                           data-trigger="hover" title="Host notification command" data-placement="bottom" data-content="{{command.__dict__}}">
                               <a href="/commands#{{command.get_name()}}">{{command.get_name()}}</a>
                               <script>
-                              $('td[name="host_command{{i}}"]')
-                                .attr('title', '{{command.get_name()}}')
-                                .attr('data-content', '{{json.dumps(command.command.command_line)}}')
-                                .popover();
+                              $(document).ready(function(){
+                                 $('td[name="host_command{{i}}"]').popover();
+                              });
                               </script>
                            </td>
                         </tr>
@@ -258,14 +260,16 @@
                      %if nw.service_notifications_enabled:
                      <tr>
                         <td><strong>&nbsp;&ndash;&nbsp;period:</strong></td>
-                        <td name="{{"service_notification_period%s" % i}}" class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" title="service notification period" data-placement="top" data-content="...">{{! app.helper.get_on_off(nw.service_notification_period.is_time_valid(time.time()), "Is notification period currently active?")}}
+                        %tp=app.datamgr.get_timeperiod(nw.service_notification_period.get_name())
+                        <td name="{{"service_notification_period%s" % i}}" class="popover-dismiss" data-html="true"
+                            data-toggle="popover" data-trigger="hover" title="{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}"
+                            data-placement="bottom" data-content="{{!app.helper.get_timeperiod_html(tp)}}">
+                            {{! app.helper.get_on_off(nw.service_notification_period.is_time_valid(time.time()), "Is notification period currently active?")}}
                            <a href="/timeperiods">{{nw.service_notification_period.alias}}</a>
                            <script>
-                            %tp=app.datamgr.get_timeperiod(nw.service_notification_period.get_name())
-                            $('td[name="{{"service_notification_period%s" % i}}"]')
-                              .attr('title', '{{tp.alias if hasattr(tp, "alias") else tp.timeperiod_name}}')
-                              .attr('data-content', '{{!app.helper.get_timeperiod_html(tp)}}')
-                              .popover();
+                           $(document).ready(function(){
+                            $('td[name="{{"service_notification_period%s" % i}}"]').popover();
+                           });
                            </script>
                         </td>
                      </tr>
@@ -296,13 +300,14 @@
                         %i += 1
                         <tr>
                            <td><strong>&nbsp;&ndash;command:</strong></td>
-                           <td name="service_command{{i}}" class="popover-dismiss" data-html="true" data-toggle="popover" data-trigger="hover" title="Service notification command" data-placement="top" data-content="...">
+                           <td name="service_command{{i}}" class="popover-dismiss" data-html="true"
+                                data-toggle="popover" data-trigger="hover" title="{{command.get_name()}}"
+                                data-placement="bottom" data-content="{{command.__dict__ }}">
                               <a href="/commands#{{command.get_name()}}">{{command.get_name()}}</a>
                               <script>
-                                 $('td[name="service_command{{i}}"]')
-                                   .attr('title', '{{command.get_name()}}')
-                                   .attr('data-content', '{{json.dumps(command.command.command_line)}}')
-                                   .popover();
+                              $(document).ready(function(){
+                                 $('td[name="service_command{{i}}"]').popover();
+                              });
                               </script>
                            </td>
                         </tr>

--- a/module/plugins/contacts/views/contacts.tpl
+++ b/module/plugins/contacts/views/contacts.tpl
@@ -1,5 +1,7 @@
 %rebase("layout", title='All contacts (%d contacts)' % len(contacts))
 
+%setdefault('fmwk', 'Shinken')
+
 %user = app.get_user()
 %helper = app.helper
 
@@ -28,20 +30,24 @@
            <td>
              {{ !helper.get_contact_avatar(contact) }}
              %if contact.is_admin:
-             <i class="fa font-warning fa-star" title="This user is admin"></i>
+             <i class="fa font-warning fa-star" title="This user is an administrator"></i>
              %elif app.can_action(contact.contact_name):
-             <i class="fa font-ok fa-star" title="This user is allow to launch commands"></i>
+             <i class="fa font-ok fa-star" title="This user is allowed to launch commands"></i>
              %end
            </td>
            <td><strong>{{ contact.alias if contact.alias != "none" else "" }}</strong></td>
            <td>
              %if contact.email != "none":
-             <a href="mailto:{{contact.email}}?subject=Sent from Shinken WebUI">{{contact.email}}</a>
+             <a href="mailto:{{contact.email}}?subject=Sent from {{fmwk}} WebUI">{{contact.email}}</a>
              %end
            </td>
            <td>
              %for nw in contact.notificationways:
+             %if isinstance(nw, dict):
+             {{ nw['notificationway_name'] }}
+             %else:
              {{ nw.get_name() }}
+             %end
              %end
            </td>
          </tr>

--- a/module/plugins/dashboard/dashboard.py
+++ b/module/plugins/dashboard/dashboard.py
@@ -92,9 +92,9 @@ def get_currently():
 
 pages = {
     get_page: {
-        'name': 'Dashboard', 'route': '/dashboard', 'view': 'dashboard'
+        'name': 'Dashboard', 'route': '/dashboard', 'view': 'dashboard', 'static': True
     },
     get_currently: {
-        'name': 'Currently', 'route': '/dashboard/currently', 'view': 'currently'
+        'name': 'Currently', 'route': '/dashboard/currently', 'view': 'currently', 'static': True
     }
 }

--- a/module/plugins/groups/views/contacts-groups-overview.tpl
+++ b/module/plugins/groups/views/contacts-groups-overview.tpl
@@ -50,7 +50,7 @@
 
                   <ul class="list-group">
                      <li class="list-group-item">
-                        {{!'<span class="badge">%s</span>Services' % (len(contacts)) if len(contacts) else '<small><em>No members</em></small>'}}
+                        {{!'<span class="badge">%s</span>Contacts' % (len(contacts)) if len(contacts) else '<small><em>No members</em></small>'}}
                      </li>
                      <li class="list-group-item">
                         {{!'<span class="badge">%s</span>Groups' % (nGroups) if nGroups else '<small><em>No sub-groups</em></small>'}}
@@ -62,6 +62,10 @@
       %end
 
       %for group in contactgroups:
+         %sub_groups = group.contactgroup_members
+         %sub_groups = [] if (sub_groups and not sub_groups[0]) else sub_groups
+
+         %nGroups=len(group.contactgroup_members)
          <li class="group list-group-item clearfix">
             <h3>
                <a role="menuitem" href="/all?search=cg:{{'"%s"' % group.get_name()}}">
@@ -86,13 +90,13 @@
                      <a class="btn btn-default" href="/minemap?search=type:host cg:{{'"%s"' % group.get_name()}}"><i class="fa fa-table"></i> <span class="hidden-xs">Minemap</span></a>
                   </div>
 
-                  <div class="btn-group btn-group-justified" role="group" aria-label="Resources" title="View resources for hosts related with this contact group">
+                  <div class="btn-group btn-group-justified" role="group" aria-label="Resources" title="View resources for contacts related with this contact group">
                      <a class="btn btn-default" href="/all?search=type:host cg:{{'"%s"' % group.get_name()}}"><i class="fa fa-clock-o"></i> <span class="hidden-xs">Resources</span></a>
                   </div>
 
                   <ul class="list-group">
                      <li class="list-group-item">
-                        {{!'<span class="badge">%s</span>Services' % (len(contacts)) if len(contacts) else '<small><em>No members</em></small>'}}
+                        {{!'<span class="badge">%s</span>Contacts' % (len(contacts)) if len(contacts) else '<small><em>No members</em></small>'}}
                      </li>
                      <li class="list-group-item">
                         {{!'<span class="badge">%s</span>Groups' % (nGroups) if nGroups else '<small><em>No sub-groups</em></small>'}}

--- a/module/plugins/groups/views/hosts-groups-dashboard.tpl
+++ b/module/plugins/groups/views/hosts-groups-dashboard.tpl
@@ -40,14 +40,16 @@
    <ul id="groups" class="list-group">
       %even='alt'
       %if level==0:
-         %nHosts=h['nb_elts']
-         %nGroups=len(hostgroups)
          <li class="all_groups list-group-item clearfix {{even}} {{'alert-danger' if h['nb_elts'] == h['nb_down'] and h['nb_elts'] != 0 else ''}}">
             <section class="left">
                <h3>
                   <a role="menuitem" href="/all?search=type:host"><i class="fa fa-angle-double-down"></i>
                      All hosts {{!helper.get_business_impact_text(h['bi'])}}
                   </a>
+
+               <span class="btn-group pull-right">
+                  <a href="{{app.get_url("HostsGroups")}}" class="btn btn-small switcher quickinfo pull-right" data-original-title='List'> <i class="fa fa-align-justify"></i> </a>
+               </span>
                </h3>
                <div>
                   %for state in 'up', 'unreachable', 'down', 'pending', 'unknown', 'ack', 'downtime':
@@ -79,9 +81,7 @@
       %i=0
       %for group in hostgroups:
          %hosts = app.datamgr.search_hosts_and_services('type:host hg:'+group.get_name(), user)
-         %h = app.datamgr.get_hosts_synthesis(user=user)
-         %nHosts=h['nb_elts']
-         %nGroups=len(group.hostgroup_members)
+         %h = app.datamgr.get_hosts_synthesis(elts=hosts, user=user)
          %if (i % 6)==0:
          <tr data-row="{{i}}">
          %end
@@ -97,7 +97,9 @@
 
             %html=''
             %for state in 'down', 'unreachable', 'up', 'pending', 'unknown', 'ack', 'downtime':
+              %if h['nb_' + state]:
               %html += helper.get_fa_icon_state_and_label(cls='host', state=state, label=h['nb_' + state])
+              %end
             %end
             <div class="col-sm-6 text-center btn popover-dismiss"
                   data-html="true" data-toggle="popover" data-trigger="hover" data-placement="bottom"
@@ -124,6 +126,30 @@
 
 
 <script type="text/javascript">
+$(document).ready(function(){
    // Tooltips
    $('[data-toggle="tooltip"]').tooltip();
+
+   // Popovers
+   $('div[data-toggle="popover"]').popover({
+      placement: 'bottom',
+      container: 'body',
+      trigger: 'manual',
+      animation: false,
+      template: '<div class="popover img-popover"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>'
+   }).on("mouseenter", function () {
+      var _this = this;
+      $(this).popover("show");
+      $(this).siblings(".popover").on("mouseleave", function () {
+          $(_this).popover('hide');
+      });
+   }).on("mouseleave", function () {
+      var _this = this;
+      setTimeout(function () {
+          if (!$(".popover:hover").length) {
+              $(_this).popover("hide");
+          }
+      }, 100);
+   });
+});
 </script>

--- a/module/plugins/user/views/user_pref.tpl
+++ b/module/plugins/user/views/user_pref.tpl
@@ -5,20 +5,26 @@
 
 %username = 'anonymous'
 %if user is not None:
-%username = user.get_name()
+%username = user.contact_name
 %end
+
+%helper=app.helper
 
 %rebase("layout", css=['user/css/user.css'], breadcrumb=[ ['User preferences', '/user/pref'] ], title='User preferences')
 
       <div class="panel panel-default">
          <div class="panel-heading">
            <h2 class="panel-title">
-             {{ username }}
-             %if app.manage_acl:
-             <i class="font-warning fa fa-star" title="Administrator"></i>
+             {{ !helper.get_contact_avatar(user, with_name=False, with_link=False) }}
+             {{ user.get_name() }}
+             %if user.is_admin:
+             <i class="fa font-warning fa-star" title="This user is an administrator"></i>
+             %elif app.can_action(username):
+             <i class="fa font-ok fa-star" title="This user is allowed to launch commands"></i>
              %end
            </h2>
          </div>
+         <div class="panel-body">
                <table class="table table-condensed" style="table-layout: fixed; word-wrap: break-word;">
                   <colgroup>
                      <col style="width: 30%" />
@@ -34,7 +40,13 @@
                         <td>{{! app.helper.get_on_off(app.can_action(), "Is this contact allowed to launch commands from Web UI?")}}</td>
                      </tr>
 
-                     %for attr, value in user.__dict__.iteritems():
+                     <tr>
+                        <td colspan="2"><h3>User attributes:</h3></td>
+                     </tr>
+                     %for attr, value in sorted(user.__dict__.iteritems()):
+                     %if attr not in ['address1', 'address2', 'address3', 'address4', 'address5', 'address6', 'alias', 'can_submit_commands', 'customs', 'email', 'host_notifications_enabled', 'host_notification_options', 'host_notification_period', 'min_business_impact', 'pager', 'service_notifications_enabled', 'service_notification_options', 'service_notification_period']:
+                     %continue
+                     %end
                      <tr>
                         <td><strong>{{attr}}:</strong></td>
                         <td>{{value}}</td>
@@ -42,16 +54,19 @@
                      %end
 
                   %if app.prefs_module.is_available():
-                  %for preference in app.prefs_module.get_ui_user_preference(user, default=[]):
-                  %if preference in ['_id']:
-                  %continue
-                  %end
+                     <tr>
+                        <td colspan="2"><h3>User preferences:</h3></td>
+                     </tr>
+                     %for preference in app.prefs_module.get_ui_user_preference(user, default=[]):
+                     %if preference in ['_id', 'uuid']:
+                     %continue
+                     %end
                      <tr>
                         <td>{{preference}}</td>
                         <td>{{app.prefs_module.get_ui_user_preference(user, preference)}}</td>
                      </tr>
-                  %end
-                  %else:
+                     %end
+
                      <tr>
                         <td>toolbar</td>
                         <td>{{app.prefs_module.get_ui_user_preference(user, 'toolbar')}}</td>
@@ -67,5 +82,6 @@
                   %end
                   </tbody>
                </table>
+         </div>
       </div>
 %end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2932687/48905286-69db0580-ee61-11e8-94e9-e99ec3cce0b4.png)

1. Some cleanings in the groups management and display.
1. Do not hide the empty groups but display a reduced view (see Linux servers).
1. Allow to switch between two views for the hosts groups (see icon on top right of All hosts).

Closes #237.

Switch forth and back between the dashboard and overview pages using the icon on top right of the **All hosts** group: 

![image](https://user-images.githubusercontent.com/2932687/48905384-b7f00900-ee61-11e8-9245-894be5c49962.png)


