### PR TITLE
Closes #357 - configure a dedicated log file for the WebUI

### DIFF
--- a/etc/modules/webui2.cfg
+++ b/etc/modules/webui2.cfg
@@ -5,6 +5,17 @@ define module {
    module_name         webui2
    module_type         webui2
 
+   # Declare the log file for the Shinken Web UI log (default is a null value)
+   # If not set, then the WebUI will make its log in the broker log file
+   # Else the WebUI will log in the broker log file and in its own log file
+   #log_file       /var/log/shinken/shinken-webui.log
+   # WebUI log level (DEBUG, INFO, WARNING, ERROR)
+   # DEBUG is very very verbose because we get all the log from the Shinken broker!
+   log_level      INFO
+   # Set log_human_date=1 to have a human readable date for the log
+   log_human_date 1
+   # Set log_backup_count to the number of days to keep log files (default is 7 days)
+   log_backup_count 7
 
    ## Modules for WebUI
    ## User authentication:

--- a/test/test-configurations/shinken/etc/modules/webui2.cfg
+++ b/test/test-configurations/shinken/etc/modules/webui2.cfg
@@ -5,6 +5,16 @@ define module {
    module_name         webui2
    module_type         webui2
 
+   # Declare the log file for the Shinken Web UI log (default is a null value)
+   # If not set, then the WebUI will make its log in the broker log file
+   # Else the WebUI will log in the broker log file and in its own log file
+   log_file       /var/log/shinken/shinken-webui.log
+   # WebUI log level (DEBUG, INFO, WARNING, ERROR)
+   log_level      INFO
+   # Set log_human_date=1 to have a human readable date for the log
+   log_human_date 1
+   # Set log_backup_count to the number of days to keep log files (default is 7 days)
+   #log_backup_count 7
 
    ## Modules for WebUI
    ## User authentication:


### PR DESCRIPTION
Closes #357 - Allow to configure a dedicated log file for the WebUI.

See the *etc/webui2.cfg* file for more information about the configuration