### PR TITLE
Use the contact_name rather than alias in the external commands

### DIFF
--- a/module/plugins/dashboard/views/currently.tpl
+++ b/module/plugins/dashboard/views/currently.tpl
@@ -1,4 +1,4 @@
-%rebase("fullscreen", css=['dashboard/css/currently.css'], js=['js/shinken-actions.js', 'dashboard/js/Chart.js'], title='Shinken currently')
+%rebase("fullscreen", css=['dashboard/css/currently.css'], js=['dashboard/js/Chart.js'], title='Shinken currently')
 %import json
 
 %user = app.get_user()

--- a/module/plugins/eltdetail/views/_eltdetail_comment_table.tpl
+++ b/module/plugins/eltdetail/views/_eltdetail_comment_table.tpl
@@ -3,7 +3,7 @@
 
 %if with_contact_form:
 <form class="form-horizontal" class="js-comment-form" action="javascript:submit_comment_form('{{ helper.get_html_id(elt) }}');">
-  <input type="hidden" id="user_{{ helper.get_html_id(elt) }}" value="{{ user.get_name() }}">
+  <input type="hidden" id="user_{{ helper.get_html_id(elt) }}" value="{{ user.get_username() }}">
   <input type="hidden" id="name_{{ helper.get_html_id(elt) }}" value="{{ helper.get_uri_name(elt) }}">
   <div class="form-group">
     <label for="comment" class="col-sm-1 hidden-xs control-label">{{ !helper.get_contact_avatar(user, with_name=False, with_link=False, size=32) }}</label>
@@ -49,7 +49,7 @@
       %end
       <span class="comment-time">
         %if with_service_name:
-        by 
+        by
         {{ !helper.get_contact_avatar(c.author) }}
         %else:
         commented

--- a/module/plugins/eltdetail/views/eltdetail.tpl
+++ b/module/plugins/eltdetail/views/eltdetail.tpl
@@ -23,7 +23,7 @@ Invalid element name
 %breadcrumb += [[elt.display_name, '/service/'+helper.get_uri_name(elt)]]
 %end
 
-%js=['js/shinken-actions.js', 'js/jquery.sparkline.min.js', 'js/shinken-charts.js', 'availability/js/justgage.js', 'availability/js/raphael-2.1.4.min.js', 'cv_host/js/flot/jquery.flot.min.js', 'cv_host/js/flot/jquery.flot.tickrotor.js', 'cv_host/js/flot/jquery.flot.resize.min.js', 'cv_host/js/flot/jquery.flot.pie.min.js', 'cv_host/js/flot/jquery.flot.categories.min.js', 'cv_host/js/flot/jquery.flot.time.min.js', 'cv_host/js/flot/jquery.flot.stack.min.js', 'cv_host/js/flot/jquery.flot.valuelabels.js', 'eltdetail/js/custom_views.js', 'eltdetail/js/eltdetail.js', 'logs/js/history.js']
+%js=['js/jquery.sparkline.min.js', 'js/shinken-charts.js', 'availability/js/justgage.js', 'availability/js/raphael-2.1.4.min.js', 'cv_host/js/flot/jquery.flot.min.js', 'cv_host/js/flot/jquery.flot.tickrotor.js', 'cv_host/js/flot/jquery.flot.resize.min.js', 'cv_host/js/flot/jquery.flot.pie.min.js', 'cv_host/js/flot/jquery.flot.categories.min.js', 'cv_host/js/flot/jquery.flot.time.min.js', 'cv_host/js/flot/jquery.flot.stack.min.js', 'cv_host/js/flot/jquery.flot.valuelabels.js', 'eltdetail/js/custom_views.js', 'eltdetail/js/eltdetail.js', 'logs/js/history.js']
 %if app.logs_module.is_available():
 %js=js + ['availability/js/justgage.js', 'availability/js/raphael-2.1.4.min.js']
 %end

--- a/module/plugins/forms/views/form_ack_add.tpl
+++ b/module/plugins/forms/views/form_ack_add.tpl
@@ -3,13 +3,13 @@
 <script type="text/javascript">
    function submit_local_form() {
       // Launch acknowledge request and bailout this modal view
-      do_acknowledge("{{name}}", $('#reason').val(), '{{user.get_name()}}', '{{app.default_ack_sticky}}', '{{app.default_ack_notify}}', '{{app.default_ack_persistent}}');
+      do_acknowledge("{{name}}", $('#reason').val(), '{{user.get_username()}}', '{{app.default_ack_sticky}}', '{{app.default_ack_notify}}', '{{app.default_ack_persistent}}');
 
       %if elt.__class__.my_type=='host':
       if ($('#ack_services').is(":checked")) {
       %for service in elt.services:
       %if service.state != service.ok_up and not service.problem_has_been_acknowledged:
-         do_acknowledge("{{name}}/{{service.get_name()}}", $('#reason').val(), '{{user.get_name()}}', '{{app.default_ack_sticky}}', '{{app.default_ack_notify}}', '{{app.default_ack_persistent}}');
+         do_acknowledge("{{name}}/{{service.get_name()}}", $('#reason').val(), '{{user.get_username()}}', '{{app.default_ack_sticky}}', '{{app.default_ack_notify}}', '{{app.default_ack_persistent}}');
       %end
       %end
       }

--- a/module/plugins/forms/views/form_ack_remove.tpl
+++ b/module/plugins/forms/views/form_ack_remove.tpl
@@ -5,16 +5,16 @@
       delete_acknowledge('{{name}}');
       // If a comment is to be added ...
       if ($('#reason').val()) {
-         add_comment("{{name}}", '{{user.get_name()}}', $('#reason').val());
+         add_comment("{{name}}", '{{user.get_username()}}', $('#reason').val());
       }
-      
+
       %if elt.__class__.my_type=='host':
       if ($('#ack_services').is(":checked")) {
       %for service in elt.services:
       %if service.problem_has_been_acknowledged:
          delete_acknowledge("{{name}}/{{service.get_name()}}");
          if ($('#reason').val()) {
-            add_comment("{{name}}/{{service.get_name()}}", '{{user.get_name()}}', $('#reason').val());
+            add_comment("{{name}}/{{service.get_name()}}", '{{user.get_username()}}', $('#reason').val());
          }
       %end
       %end
@@ -38,11 +38,11 @@
          <input name="ack_services" id="ack_services" type="checkbox" checked="checked">Delete acknowledge for all services for the host?</input>
       </div>
       %end
-      
+
     <div class="form-group">
       <textarea name="reason" id="reason" class="form-control" rows="5" placeholder="Comment ...">Acknowledge deleted from WebUI by {{user.get_name()}}.</textarea>
     </div>
-    
+
     <a href="javascript:submit_local_form();" class="btn btn-danger btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
   </form>
 </div>

--- a/module/plugins/forms/views/form_downtime_add.tpl
+++ b/module/plugins/forms/views/form_downtime_add.tpl
@@ -7,12 +7,12 @@
 
    function submit_local_form(){
       // Launch downtime request and bailout this modal view
-     do_schedule_downtime("{{name}}", downtime_start.format('X'), downtime_stop.format('X'), '{{user.get_name()}}', $('#reason').val(), '{{app.shinken_downtime_fixed}}', '{{app.shinken_downtime_trigger}}', '{{app.shinken_downtime_duration}}');
+     do_schedule_downtime("{{name}}", downtime_start.format('X'), downtime_stop.format('X'), '{{user.get_username()}}', $('#reason').val(), '{{app.shinken_downtime_fixed}}', '{{app.shinken_downtime_trigger}}', '{{app.shinken_downtime_duration}}');
 
       %if elt.__class__.my_type=='host':
       if ($('#dwn_services').is(":checked")) {
       %for service in elt.services:
-         do_schedule_downtime("{{name}}/{{service.get_name()}}", downtime_start.format('X'), downtime_stop.format('X'), '{{user.get_name()}}', $('#reason').val(), '{{app.shinken_downtime_fixed}}', '{{app.shinken_downtime_trigger}}', '{{app.shinken_downtime_duration}}');
+         do_schedule_downtime("{{name}}/{{service.get_name()}}", downtime_start.format('X'), downtime_stop.format('X'), '{{user.get_username()}}', $('#reason').val(), '{{app.shinken_downtime_fixed}}', '{{app.shinken_downtime_trigger}}', '{{app.shinken_downtime_duration}}');
       %end
       }
       %end

--- a/module/plugins/forms/views/form_downtime_delete_all.tpl
+++ b/module/plugins/forms/views/form_downtime_delete_all.tpl
@@ -5,7 +5,7 @@
       delete_all_downtimes("{{name}}");
       // If a comment is to be added ...
       if ($('#reason').val()) {
-         add_comment("{{name}}", '{{user.get_name()}}', $('#reason').val());
+         add_comment("{{name}}", '{{user.get_username()}}', $('#reason').val());
       }
 
       %if elt.__class__.my_type=='host':
@@ -39,7 +39,7 @@
       <div class="form-group">
          <textarea name="reason" id="reason" class="form-control" rows="5" placeholder="Comment…">All dowtimes deleted for {{name}} by {{user.get_name()}}.</textarea>
       </div>
-  
+
       <a href="javascript:submit_local_form();" class="btn btn-danger btn-lg btn-block"> <i class="fa fa-save"></i> Submit</a>
    </form>
 </div>

--- a/module/plugins/forms/views/form_submit_check.tpl
+++ b/module/plugins/forms/views/form_submit_check.tpl
@@ -2,7 +2,7 @@
 <script type="text/javascript">
    function submit_local_form() {
       submit_check("{{name}}", $('#return_code').val(), $('#output').val());
-      add_comment("{{name}}", '{{user.get_name()}}', "Submitted a check result: "+$('#return_code').val()+" - "+$('#output').val());
+      add_comment("{{name}}", '{{user.get_username()}}', "Submitted a check result: "+$('#return_code').val()+" - "+$('#output').val());
       $('#modal').modal('hide')
    }
 </script>

--- a/module/plugins/problems/views/problems.tpl
+++ b/module/plugins/problems/views/problems.tpl
@@ -4,7 +4,7 @@
 %datamgr = app.datamgr
 %search_string = app.get_search_string()
 
-%rebase("layout", title=title, js=['js/shinken-actions.js', 'js/jquery.sparkline.min.js', 'js/shinken-charts.js', 'problems/js/problems.js'], css=['problems/css/problems.css'], navi=navi, page="/all", elts_per_page=elts_per_page)
+%rebase("layout", title=title, js=['js/jquery.sparkline.min.js', 'js/shinken-charts.js', 'problems/js/problems.js'], css=['problems/css/problems.css'], navi=navi, page="/all", elts_per_page=elts_per_page)
 
 <script type="text/javascript">
    var actions_enabled = {{'true' if app.can_action() else 'false'}};

--- a/module/views/layout.tpl
+++ b/module/views/layout.tpl
@@ -111,7 +111,7 @@
                   <!-- Page header -->
                   <section class="content-header">
                      %if navi:
-                     %include("pagination_element", navi=navi, page=page)
+                     %include("pagination_element", navi=navi, page=page, elts_per_page=elts_per_page, display_steps_form=True, drop="dropdown")
                      %end
                      <h3 class="page-header" style="margin-top: 10px">
                        <ol class="breadcrumb" style="margin:0px">
@@ -142,7 +142,7 @@
                   %if navi and len(navi) > 1:
                   <hr>
                   <section class="pagination-footer">
-                   %include("pagination_element", navi=navi, page=page, elts_per_page=elts_per_page, display_steps_form=True)
+                  %include("pagination_element", navi=navi, page=page, elts_per_page=elts_per_page, display_steps_form=True, drop="dropup")
                   </section>
                   %end
                </div>
@@ -212,6 +212,7 @@
       var app_refresh_period = {{app.refresh_period}};
       </script>
       <script src="/static/js/shinken-refresh.js?v={{app.app_version}}"></script>
+      <script src="/static/js/shinken-actions.js?v={{app.app_version}}"></script>
       %end
 
       <script src="/static/js/shinken-layout.js?v={{app.app_version}}"></script>

--- a/module/views/pagination_element.tpl
+++ b/module/views/pagination_element.tpl
@@ -2,14 +2,15 @@
 %setdefault('div_class', "pull-right")
 %setdefault('ul_class', "")
 %setdefault('div_style', "margin-top:-15px;")
+%setdefault('drop', "dropup")
 
 <div class="{{ div_class }}" style="{{ div_style }}">
   %if display_steps_form and elts_per_page is not None:
   <ul class="pagination {{ ul_class }}" >
     <li>
-      <form id="elts_per_page" class="pull-left">
+      <form id="elts_per_page" method="get" action="/{{page}}">
        <div class="input-group" style="width:120px">
-         <div class="input-group-btn dropup">
+         <div class="input-group-btn {{drop}}">
            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">#&nbsp;<span class="caret"></span></button>
            <ul class="dropdown-menu" role="menu">
              <li><a href="#" data-elts="5">5 elements</a></li>
@@ -19,7 +20,7 @@
              <li><a href="#" data-elts="100">100 elements</a></li>
            </ul>
          </div>
-         <input type="number" class="form-control" aria-label="Elements per page" placeholder="Elements per page ..." value="{{elts_per_page}}" style="max-width: 100px;">
+         <input id="step" name="step" type="number" class="form-control" aria-label="Elements per page" placeholder="Elements per page ..." value="{{elts_per_page}}" style="max-width: 100px;">
        </div>
       </form>
     </li>
@@ -27,19 +28,21 @@
     var current_elts_per_page = {{elts_per_page}};
     $("#elts_per_page li a").click(function(e){
       var value = $(this).data('elts');
-      
+
       // Save user preference
       save_user_preference('elts_per_page', value);
-      
+
       // Update input field
       $('#elts_per_page input').val(value);
-      
+
       current_elts_per_page = value;
 
-      e.preventDefault();
+      $("#elts_per_page").submit();
+      //e.preventDefault();
     });
     $('#elts_per_page form').submit(function(e){
       var value = $('#elts_per_page input').val();
+      console.log("Submit: ", value);
 
       if (value == parseInt(value)) {
          // Update input field
@@ -49,10 +52,12 @@
          $('#elts_per_page input').val(current_elts_per_page);
       }
 
-      e.preventDefault();
+      $("#elts_per_page").submit();
+      //e.preventDefault();
     });
     $('#elts_per_page input').blur(function(e){
       var value = $('#elts_per_page input').val();
+      console.log("Blur: ", value);
 
       if (value == parseInt(value)) {
          // Update input field
@@ -62,15 +67,16 @@
          $('#elts_per_page input').val(current_elts_per_page);
       }
 
-      e.preventDefault();
+      $("#elts_per_page").submit();
+      //e.preventDefault();
     });
     </script>
   </ul>
   %end
-  
+
   %if navi and len(navi) > 1:
   <ul class="pagination {{ ul_class }}" >
-    
+
     %from urllib import urlencode
 
     %for name, start, end, is_current in navi:


### PR DESCRIPTION
Using the get_name() function for the name of the user in the external comands is not consistent ... Nagios / Shinken / Alignak expect the contact_name property and not the display_name nor alias one