### PR TITLE
BI management cleaning

### DIFF
--- a/module/htdocs/js/shinken-actions.js
+++ b/module/htdocs/js/shinken-actions.js
@@ -603,7 +603,6 @@ $("body").on("click", ".js-recheck", function () {
         recheck_now(elt);
     } else {
         $.each(selected_elements, function(idx, name){
-            console.log("Recheck selected", elt);
             recheck_now(name);
         });
     }

--- a/module/htdocs/js/shinken-actions.js
+++ b/module/htdocs/js/shinken-actions.js
@@ -599,9 +599,11 @@ $("body").on("click", ".js-recheck", function () {
     var elt = get_action_element($(this));
 
     if (elt) {
+        console.log(elt);
         recheck_now(elt);
     } else {
         $.each(selected_elements, function(idx, name){
+            console.log("Recheck selected", elt);
             recheck_now(name);
         });
     }

--- a/module/module.py
+++ b/module/module.py
@@ -35,6 +35,7 @@ WEBUI_COPYRIGHT = "2009-2018"
 WEBUI_LICENSE = "License GNU AGPL as published by the FSF, minimum version 3 of the License."
 
 import os
+import re
 import string
 import random
 import traceback
@@ -82,7 +83,7 @@ from bottle import route, request, response, template
 import bottle
 
 # Local import
-from datamanager import WebUIDataManager
+from datamanager import WebUIDataManager, SEARCH_QUERY_PATTERNS
 from ui_user import User
 from helper import helper
 
@@ -1052,7 +1053,56 @@ class Webui_broker(BaseModule, Daemon):
         return lst
 
     def get_search_string(self, default=""):
-        return self.request.query.get('search', default)
+        """Manage the query parameter `search`
+
+        The business impact logic behind this:
+        - the UI defined BI (problems_business_impact) is considered first
+        - the user minimum BI is then considered
+
+        Thus, the maximum value of both BIs is added as a filter in the search query if no
+        BI is specified in the search query. If more than one bi: exist in the search query
+        the last one is the only one that is kept in the query parameter.
+        """
+        if not self.request.route.config.get('search_engine', None):
+            # Requested URL do not include the search engine
+            logger.debug("No search engine on this page!")
+            return ''
+
+        search_string = self.request.query.get('search', default)
+
+        # Force include the UI BI in the search query if it is not yet present
+        bi = self.problems_business_impact
+        if "bi:" not in search_string:
+            # Include BI as the first search criterion
+            return ("bi:>=%d " % bi) + search_string
+
+        # Search patterns like: isnot:0 isnot:ack isnot:"downtime fred" name "vm fred"
+        regex = re.compile(SEARCH_QUERY_PATTERNS, re.VERBOSE)
+        logger.debug("Search string: %s", search_string)
+        new_ss = ''
+        for match in regex.finditer(search_string):
+            if not match.group('key'):
+                continue
+            if match.group('key') not in ['bp', 'bi']:
+                logger.debug("- match: %s / %s", match.group('key'), match.group('value'))
+                new_ss += match.group('key')
+                new_ss += match.group('value')
+                continue
+            logger.debug("Found BI filter: %s", match.group('value'))
+            s = match.group('value')
+            bi = self.problems_business_impact
+            try:
+                if s.startswith('>=') or s.startswith('<='):
+                    bi = int(s[2:])
+                elif s.startswith('>') or s.startswith('<') or s.startswith('='):
+                    bi = int(s[1:]) + 1
+            except ValueError:
+                pass
+            logger.debug("- search BI is >=%d", bi)
+        new_ss = ("bi:>=%d " % bi) + new_ss
+        logger.debug("- updated search string: %s", new_ss)
+
+        return new_ss
 
     def redirect404(self, msg="Not found"):
         raise self.bottle.HTTPError(404, msg)

--- a/module/module.py
+++ b/module/module.py
@@ -1071,10 +1071,11 @@ class Webui_broker(BaseModule, Daemon):
         search_string = self.request.query.get('search', default)
 
         # Force include the UI BI in the search query if it is not yet present
-        bi = self.problems_business_impact
+        user = self.request.environ['USER']
+        bi = user.min_business_impact or self.problems_business_impact
         if "bi:" not in search_string:
-            # Include BI as the first search criterion
-            return ("bi:>=%d " % bi) + search_string
+            # Include BI as the last search criterion
+            return search_string + (" bi:>=%d" % bi)
 
         # Search patterns like: isnot:0 isnot:ack isnot:"downtime fred" name "vm fred"
         regex = re.compile(SEARCH_QUERY_PATTERNS, re.VERBOSE)
@@ -1085,8 +1086,8 @@ class Webui_broker(BaseModule, Daemon):
                 continue
             if match.group('key') not in ['bp', 'bi']:
                 logger.debug("- match: %s / %s", match.group('key'), match.group('value'))
-                new_ss += match.group('key')
-                new_ss += match.group('value')
+                new_ss += match.group('key') + ':'
+                new_ss += match.group('value') + ' '
                 continue
             logger.debug("Found BI filter: %s", match.group('value'))
             s = match.group('value')
@@ -1099,7 +1100,7 @@ class Webui_broker(BaseModule, Daemon):
             except ValueError:
                 pass
             logger.debug("- search BI is >=%d", bi)
-        new_ss = ("bi:>=%d " % bi) + new_ss
+        new_ss = new_ss + ("bi:>=%d" % bi)
         logger.debug("- updated search string: %s", new_ss)
 
         return new_ss

--- a/module/module.py
+++ b/module/module.py
@@ -956,12 +956,20 @@ class Webui_broker(BaseModule, Daemon):
                 return False
 
             user = User.from_contact(c)
+            logger.info("[WebUI] User minimum business impact: %s", user.min_business_impact)
 
             self.user_session = self.auth_module.get_session()
             logger.info("[WebUI] User session: %s", self.user_session)
             self.user_info = self.auth_module.get_user_info()
             logger.info("[WebUI] User information: %s", self.user_info)
 
+            # Raise an lert if the user has a BI defined and this BI is lower than the UI's one
+            if user.min_business_impact and user.min_business_impact < self.problems_business_impact:
+                logger.warning("[WebUI] the user minimum business impact (%d) is lower than "
+                               "the UI configured business impact (%d). You should update the UI "
+                               "configuration to suit your users configuration. Some items will be "
+                               "filtered wheres the user may expect to view them!",
+                               user.min_business_impact, self.problems_business_impact)
             return True
 
         logger.warning("[WebUI] The user '%s' has not been authenticated.", username)

--- a/module/plugins/problems/problems.py
+++ b/module/plugins/problems/problems.py
@@ -35,7 +35,7 @@ DEFAULT_FILTER = "isnot:UP isnot:OK isnot:PENDING isnot:ACK isnot:DOWNTIME isnot
 
 
 def get_page():
-    app.bottle.redirect("/all?search=%s" % DEFAULT_FILTER)
+    app.bottle.redirect("/all?search=bi:>=%d %s" % (app.problems_business_impact, DEFAULT_FILTER))
 
 
 def get_all():

--- a/module/plugins/problems/problems.py
+++ b/module/plugins/problems/problems.py
@@ -35,14 +35,18 @@ DEFAULT_FILTER = "isnot:UP isnot:OK isnot:PENDING isnot:ACK isnot:DOWNTIME isnot
 
 
 def get_page():
-    app.bottle.redirect("/all?search=bi:>=%d %s" % (app.problems_business_impact, DEFAULT_FILTER))
+    user = app.bottle.request.environ['USER']
+    app.bottle.redirect("/all?search=%s bi:>=%d"
+                        % (DEFAULT_FILTER,
+                           user.min_business_impact or app.problems_business_impact))
 
 
 def get_all():
     user = app.bottle.request.environ['USER']
 
     # Update the default filter according to the logged-in user minimum business impact
-    default_filtering = DEFAULT_FILTER + " bi:>=%d" % (user.min_business_impact)
+    default_filtering = DEFAULT_FILTER + " bi:>=%d" \
+                        % (user.min_business_impact or app.problems_business_impact)
 
     # Fetch elements per page preference for user, default is 25
     elts_per_page = app.prefs_module.get_ui_user_preference(user, 'elts_per_page', 25)

--- a/module/plugins/user/views/user_pref.tpl
+++ b/module/plugins/user/views/user_pref.tpl
@@ -15,13 +15,8 @@
       <div class="panel panel-default">
          <div class="panel-heading">
            <h2 class="panel-title">
-             {{ !helper.get_contact_avatar(user, with_name=False, with_link=False) }}
+             {{ ! helper.get_contact_avatar(user, with_name=False, with_link=False) }}
              {{ user.get_name() }}
-             %if user.is_admin:
-             <i class="fa font-warning fa-star" title="This user is an administrator"></i>
-             %elif app.can_action(username):
-             <i class="fa font-ok fa-star" title="This user is allowed to launch commands"></i>
-             %end
            </h2>
          </div>
          <div class="panel-body">
@@ -36,13 +31,33 @@
                         <td>{{"%s (%s)" % (user.alias, user.contact_name) if user.alias != 'none' else user.contact_name}}</td>
                      </tr>
                      <tr>
+                        <td><strong>Administrator:</strong></td>
+                        <td>{{! app.helper.get_on_off(user.is_admin, "Is this contact an administrator?")}}
+                        %if user.is_admin:
+                        <i class="fa fa-fw font-black fa-eye" title="This user is an administrator"></i>
+                        %end
+                        </td>
+                     </tr>
+                     <tr>
                         <td><strong>Commands authorized:</strong></td>
-                        <td>{{! app.helper.get_on_off(app.can_action(), "Is this contact allowed to launch commands from Web UI?")}}</td>
+                        <td>{{! app.helper.get_on_off(app.can_action(), "Is this contact allowed to launch commands from Web UI?")}}
+                        %if app.can_action(username):
+                        <i class="fa fa-fw font-black fa-bullhorn" title="This user is allowed to launch commands"></i>
+                        %end
+                        </td>
                      </tr>
                      <tr>
                         <td><strong>Minimum business impact:</strong></td>
                         <td>{{!helper.get_business_impact_text(user.min_business_impact, text=True)}}</td>
                      </tr>
+                     %# Raise an alert if the user has a BI defined and this BI is lower than the UI's one
+                     %if user.min_business_impact and user.min_business_impact < app.problems_business_impact:
+                     <tr>
+                        <td colspan="2"><span class="alert-warning">
+                        The UI is configured for a minimum business impact ({{! helper.get_business_impact_text(app.problems_business_impact, text=True) }}). You may not view some hosts/services that you are searching for...
+                        </span></td>
+                     </tr>
+                     %end
 
                      <tr>
                         <td colspan="2"><h3>User attributes:</h3></td>
@@ -53,7 +68,11 @@
                      %end
                      <tr>
                         <td><strong>{{attr}}:</strong></td>
+                        %if value or (isinstance(value, list) and value[0]):
                         <td>{{value}}</td>
+                        %else:
+                        <td>-</td>
+                        %end
                      </tr>
                      %end
 

--- a/module/views/_filters.tpl
+++ b/module/views/_filters.tpl
@@ -26,12 +26,20 @@
                <li role="presentation"><a role="menuitem" href="/all?search=is:ack&title=Acknowledged problems">Acknowledged problems</a></li>
                <li role="presentation"><a role="menuitem" href="/all?search=is:downtime&title=Scheduled downtimes">Scheduled downtimes</a></li>
                <li role="presentation" class="divider"></li>
-               %business_impact = max(user.min_business_impact, app.problems_business_impact)
+               %if user.is_administrator():
+               %# Only administrators are allowed to view any BI
+               %for idx in range(5, -1, -1):
+               <li role="presentation"><a role="menuitem" href="?search=bi:>={{ idx }}">Impact : {{! helper.get_business_impact_text(idx, text=True)}}</a></li>
+               %end
+               %else:
+               %# Other users are restricted to their own BI or the UI's configured BI
+               %business_impact = user.min_business_impact or app.problems_business_impact
                %for idx in range(5, business_impact - 1, -1):
                <li role="presentation"><a role="menuitem" href="?search=bi:>={{ idx }}">Impact : {{! helper.get_business_impact_text(idx, text=True)}}</a></li>
                %end
                %for idx in range(business_impact - 1, -1, -1):
                <li role="presentation" class="disabled"><a role="menuitem" class="disabled" href="?search=bi:>={{ idx }}">Impact : {{! helper.get_business_impact_text(idx, text=True)}}</a></li>
+               %end
                %end
                <li role="presentation" class="divider"></li>
                <li role="presentation"><a role="menuitem" onclick="display_modal('/modal/helpsearch')"><strong><i class="fa fa-question-circle"></i> Search syntax</strong></a></li>

--- a/module/views/_filters.tpl
+++ b/module/views/_filters.tpl
@@ -26,12 +26,13 @@
                <li role="presentation"><a role="menuitem" href="/all?search=is:ack&title=Acknowledged problems">Acknowledged problems</a></li>
                <li role="presentation"><a role="menuitem" href="/all?search=is:downtime&title=Scheduled downtimes">Scheduled downtimes</a></li>
                <li role="presentation" class="divider"></li>
-               <li role="presentation"><a role="menuitem" href="?search=bp:>=5">Impact : {{!helper.get_business_impact_text(5, text=True)}}</a></li>
-               <li role="presentation"><a role="menuitem" href="?search=bp:>=4">Impact : {{!helper.get_business_impact_text(4, text=True)}}</a></li>
-               <li role="presentation"><a role="menuitem" href="?search=bp:>=3">Impact : {{!helper.get_business_impact_text(3, text=True)}}</a></li>
-               <li role="presentation"><a role="menuitem" href="?search=bp:>=2">Impact : {{!helper.get_business_impact_text(2, text=True)}}</a></li>
-               <li role="presentation"><a role="menuitem" href="?search=bp:>=1">Impact : {{!helper.get_business_impact_text(1, text=True)}}</a></li>
-               <li role="presentation"><a role="menuitem" href="?search=bp:>=0">Impact : {{!helper.get_business_impact_text(0, text=True)}}</a></li>
+               %business_impact = max(user.min_business_impact, app.problems_business_impact)
+               %for idx in range(5, business_impact - 1, -1):
+               <li role="presentation"><a role="menuitem" href="?search=bi:>={{ idx }}">Impact : {{! helper.get_business_impact_text(idx, text=True)}}</a></li>
+               %end
+               %for idx in range(business_impact - 1, -1, -1):
+               <li role="presentation" class="disabled"><a role="menuitem" class="disabled" href="?search=bi:>={{ idx }}">Impact : {{! helper.get_business_impact_text(idx, text=True)}}</a></li>
+               %end
                <li role="presentation" class="divider"></li>
                <li role="presentation"><a role="menuitem" onclick="display_modal('/modal/helpsearch')"><strong><i class="fa fa-question-circle"></i> Search syntax</strong></a></li>
             </ul>

--- a/test/test-configurations/shinken/etc/arbiter/objects/contacts/admin.cfg
+++ b/test/test-configurations/shinken/etc/arbiter/objects/contacts/admin.cfg
@@ -18,3 +18,20 @@ define contact{
    can_submit_commands           1
 }
 
+define contact{
+   use                           generic-contact
+   contact_name                  admin2
+   alias                         Administrator 2
+
+#   email                         alignak@localhost
+#   pager                         0600000000
+
+   # Minium business impact - Normal and more important only
+   min_business_impact           3
+
+   # Only useful for the UI...
+   password                      admin2
+   is_admin                      1
+   can_submit_commands           1
+}
+

--- a/test/test-configurations/shinken/etc/arbiter/objects/contacts/guest.cfg
+++ b/test/test-configurations/shinken/etc/arbiter/objects/contacts/guest.cfg
@@ -8,11 +8,27 @@ define contact{
 
    email                         guest@localhost
 
+   # Minium business impact - All elements
+   min_business_impact           0
+
+   # Only useful for the UI...
+   password                      guest
+   is_admin                      0
+   can_submit_commands           0
+}
+
+define contact{
+   use                           generic-contact
+   contact_name                  guest2
+   alias                         Guest
+
+   email                         guest@localhost
+
    # Minium business impact - Only important elements
    min_business_impact           3
 
    # Only useful for the UI...
-   password                      guest
+   password                      guest2
    is_admin                      0
    can_submit_commands           0
 }

--- a/test/test-configurations/shinken/etc/arbiter/objects/hosts/localhost2.cfg
+++ b/test/test-configurations/shinken/etc/arbiter/objects/hosts/localhost2.cfg
@@ -9,8 +9,6 @@ define host{
 
    contact_groups		   admins
 
-    tags                +fred
-
    _satellites          arbiter-master$(arbiter)$$(arbiter-master)$$(7770)$,\
                         scheduler-master$(scheduler)$$(scheduler-master)$$(7768)$,\
                         scheduler-second$(scheduler)$$(scheduler-second)$$(17768)$,\

--- a/test/test-configurations/shinken/etc/modules/webui2.cfg
+++ b/test/test-configurations/shinken/etc/modules/webui2.cfg
@@ -166,23 +166,32 @@ define module {
 
    # Visual alerting thresholds
    # --------------------------
+   # problems_business_impact is the main UI filter
    # All the hosts and services that are in a HARD non OK/UP state are considered as problems if their
    # business_impact is greater than or equal this value
 
-   # problems_business_impact is the main UI filter
-   # the UI views are filtered according to this value which defaults to 0 (no filtering)
+   # The UI views are filtered according to this value which defaults to 1 (ignore only no importance)
+   # Shinken/Alignak consider 0 as 'no importance' hosts or services
+   # 0 - no-importance
+   # 1 - qualification
+   # 2 - normal
+   # 3 - production
+   # 4 - important
+   # 5 - top-for-business
    #problems_business_impact               1
-   # important_problems_business_impact is used to filter the alerting badges in the header bar (default is 2)
-   #important_problems_business_impact     2
+
+   # The important_problems_business_impact value is used currently to display alert badges in the
+   # top navigation bar. This allows to visually alert only for the most important problems
+   #important_problems_business_impact     3
 
    # Note that the connected user may also have his/her own min_business_impact. This filter is taking
-   # precedence over the UI min_business_impact which takes precedence over the important_problems_business_impact!
+   # precedence over the UI problems_business_impact which takes precedence over the important_problems_business_impact!
 
-   # Set to 0 to deactivate Web UI own problems computation rules
-   # This will make the WebUI build its own 'problem' state for the hosts and services
+   # Set to 1 to deactivate Web UI own problems computation rules
+   # As per default the WebUI builds its own 'problem' state for the hosts and services
    # This makes the UI more consistent for the end-users
-   # If 0, the is_problem state of Shinken/Alignak is used to count the problems.
-   #inner_problems_count          0
+   # If 1, the is_problem state of Shinken/Alignak is used to count and report the problems.
+   #disable_inner_problems_computation          0
 
    # Used in the dashboard view to select background color for percentages
    #hosts_states_warning       95


### PR DESCRIPTION
As discussed, BI (business impact) management:
- the UI has its own minimum BI (`problems_business_impact`) and the logged-in user has its own minimum BI (`min_business_impact`)
- the UI views are filtered per default with the UI minimum BI
- the search engine allows to specify BI criteria (bi>, bi<=, ...)
-----

Some cleaning in the BI management:
-when the UI and user BI are not consistent, an alert log is emitted and an information is displayed in the user preferences view
- the BI filters in the search menu are disabled if not allowed because of the configuration
- if no BI filter is specified in the search string, the default UI BI is prepended to the search query
- if several BI exist in the search query, only the last one is kept and prepended to the query

**Note** that prepending the BI in the search query will improve the search and make the BI always visible to the end user