### PR TITLE
Fix a CSS media query for width around 992px

### DIFF
--- a/module/htdocs/css/shinken-layout.css
+++ b/module/htdocs/css/shinken-layout.css
@@ -389,12 +389,7 @@ td .ellipsis > .long-output {
 }
 @media (min-width: 992px) {
     #search {
-        width: 370px;
-    }
-}
-@media (min-width: 992px) {
-    #search {
-        width: 370px;
+        width: 360px;
     }
 }
 @media (min-width: 1280px) {


### PR DESCRIPTION
The input field in the navbar is some few pixels too large on screen width 992px ...